### PR TITLE
fix a bug: golang walks some dirs like /proc/tty under linuxkit but not linux

### DIFF
--- a/pkg/namespace/ino_arbitrator.go
+++ b/pkg/namespace/ino_arbitrator.go
@@ -40,6 +40,7 @@ func (i *InoArbitrator) init() (err error) {
 	i.MinIno = inoList[0]
 	i.MaxIno = inoList[len(inoList)-1]
 	log.Logger.Debugf("min ino: %d, max ino: %d", i.MinIno, i.MaxIno)
+	//log.Logger.Debugf("inoList: %+v", i.InoList)
 	return
 }
 
@@ -47,6 +48,7 @@ func (i *InoArbitrator) GuessNetworkNamespaceInitialIno() (initialIno int) {
 	for index, ino := range i.InoList[1:] {
 		if ino-i.InoList[index] >= 3 {
 			initialIno = i.InoList[index] + 2
+			log.Logger.Debugf("InoList[%d]=%d, InoList[%d]=%d", index+1, ino, index, i.InoList[index])
 			log.Logger.Debugf("network ns initial ino maybe: %d", initialIno)
 			return
 		}

--- a/pkg/namespace/listdir.go
+++ b/pkg/namespace/listdir.go
@@ -44,33 +44,36 @@ func ListNamespaceDir(path string) (namespaceInoMap map[string]int, names []stri
 	return
 }
 
-// ReadInodeNumberMapUnderProc return map[path]ino by walk procfs, pass /proc/pid dir
+// ReadInodeNumberMapUnderProc return map[path]ino by walk procfs, skip /proc/pid
 func ReadInodeNumberMapUnderProc(proc string) (inoMap map[string]int, err error) {
 	inoMap = make(map[string]int)
 	err = filepath.Walk(proc, func(path string, info fs.FileInfo, err error) error {
+		//log.Logger.Debugf("walk %s", path)
 		if err != nil {
+			//awesome_error.CheckDebug(err)
 			return nil
 		}
 		if path == proc {
 			return nil
 		}
+		if path == filepath.Join(proc, "sys") && info.IsDir() {
+			return filepath.SkipDir
+		}
 		for _, p := range maskOrReadonlyPath {
 			if path == filepath.Join(proc, p) {
-				return filepath.SkipDir
+				if info.IsDir() {
+					return filepath.SkipDir
+				} else {
+					return nil
+				}
 			}
 		}
-		// pass net->self, self->pid ...
-		if info.Mode() == fs.ModeSymlink {
+		if _, err := strconv.Atoi(info.Name()); err == nil && filepath.Join(proc, info.Name()) == path && info.IsDir() {
 			return filepath.SkipDir
 		}
-		if _, err := strconv.Atoi(info.Name()); filepath.Join(proc, info.Name()) == path && err == nil {
-			return filepath.SkipDir
-		}
+		//log.Logger.Debugf("stat %s", path)
 		ino := int(info.Sys().(*syscall.Stat_t).Ino)
 		inoMap[path] = ino
-		if path == filepath.Join(proc, "sys") {
-			return filepath.SkipDir
-		}
 		return nil
 	})
 	if err != nil {
@@ -85,7 +88,7 @@ func ReadInodeNumberListUnderProc(proc string) (inoList []int, err error) {
 	if err != nil {
 		return
 	}
-	// log.Logger.Debugf("ino map under /proc: %+v", inoMap)
+	//log.Logger.Debugf("ino map under /proc: %+v", inoMap)
 	for _, ino := range inoMap {
 		inoList = append(inoList, ino)
 	}


### PR DESCRIPTION
skipDir only when fileinfo is a dir