### PR TITLE
[fix] cve-2024-23650: sourcepoliyc: use CheckFatal for error handling…

### DIFF
--- a/vul/cve-2024-23650/exploit.go
+++ b/vul/cve-2024-23650/exploit.go
@@ -95,7 +95,8 @@ func NilSourcePolicy(ctx context.Context, c gateway.Client) (res *gateway.Result
 	}
 	res, err = c.Solve(ctx, req)
 	if err != nil {
-		awesome_error.CheckErr(err)
+		// use fatal instead of err to avoid reactive buildkit.service by access socket
+		awesome_error.CheckFatal(err)
 		return
 	}
 	return


### PR DESCRIPTION
… in exploit to prevent reactive buildkit.service