### PR TITLE
feat(env/sysctl): add support for `kernel.unprivileged_userns_clone`

### DIFF
--- a/env/sysctl/print.go
+++ b/env/sysctl/print.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Result struct {
-	Name              result.Title
-	RouteLocalNet     item.Bool  `json:"route_localnet"`
-	MaxUserNamespaces item.Short `json:"max_user_namespaces"`
+	Name                    result.Title
+	RouteLocalNet           item.Bool  `json:"route_localnet"`
+	MaxUserNamespaces       item.Short `json:"max_user_namespaces"`
+	UnprivilegedUsernsClone item.Bool  `json:"unprivileged_userns_clone"`
 }
 
 func Human(machine container.Sysctl) (human Result) {
@@ -29,6 +30,11 @@ func Human(machine container.Sysctl) (human Result) {
 			Name:        "user.max_user_namespaces",
 			Description: "",
 			Result:      fmt.Sprintf("%d", machine.MaxUserNamespaces),
+		},
+		UnprivilegedUsernsClone: item.Bool{
+			Name:        "kernel.unprivileged_userns_clone",
+			Description: "allow unprivileged process create user namespace",
+			Result:      machine.UnprivilegedUsernsClone,
 		},
 	}
 	return

--- a/env/sysctl/sysctl.go
+++ b/env/sysctl/sysctl.go
@@ -16,12 +16,19 @@ func Sysctl() (container.Sysctl, error) {
 	if err != nil {
 		return container.Sysctl{}, err
 	}
+	unprivilegedUsernsClone, err := sysctl.UnprivilegedUsernsCloneEnabled()
+	if err != nil {
+		return container.Sysctl{}, err
+	}
 	return container.Sysctl{
 		Net: container.Net{
 			RouteLocalNet: routeLocalNetEnabled,
 		},
 		User: container.User{
 			MaxUserNamespaces: maxUserNamespaces,
+		},
+		KernelSysctl: container.KernelSysctl{
+			UnprivilegedUsernsClone: unprivilegedUsernsClone,
 		},
 	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/containerd/api v1.9.0
 	github.com/containerd/ttrpc v1.2.7
 	github.com/containerd/typeurl v1.0.2
-	github.com/ctrsploit/sploit-spec v0.6.1-rc1
+	github.com/ctrsploit/sploit-spec v0.6.1-rc2
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/docker v28.4.0+incompatible
 	github.com/go-git/go-git/v6 v6.0.0-20250906064640-2917a7134436

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/ctrsploit/sploit-spec v0.6.1-rc1 h1:EQFuvnlliabtdcCXZ8zqpSFgMcxengIAV0jNx7SeEWc=
-github.com/ctrsploit/sploit-spec v0.6.1-rc1/go.mod h1:8SEHnTOBTwXdgp/9LV6ZwDPXx5B9pQOJuf0X5w7qd7Q=
+github.com/ctrsploit/sploit-spec v0.6.1-rc2 h1:drVwAHOWtiDtj5DVe3VN+dKyNzeqfDcj7zfcJDcbZqY=
+github.com/ctrsploit/sploit-spec v0.6.1-rc2/go.mod h1:8SEHnTOBTwXdgp/9LV6ZwDPXx5B9pQOJuf0X5w7qd7Q=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/sysctl/kernel.go
+++ b/pkg/sysctl/kernel.go
@@ -1,0 +1,18 @@
+package sysctl
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	PathUnprivilegedUsernsClone = "/proc/sys/kernel/unprivileged_userns_clone"
+)
+
+func UnprivilegedUsernsCloneEnabled() (bool, error) {
+	content, err := os.ReadFile(PathUnprivilegedUsernsClone)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(content)) == "1", nil
+}

--- a/pkg/sysctl/net.go
+++ b/pkg/sysctl/net.go
@@ -1,7 +1,6 @@
 package sysctl
 
 import (
-	"fmt"
 	"os"
 	"strings"
 )
@@ -23,7 +22,7 @@ https://github.com/kubernetes/kubernetes/issues/90259
 func RouteLocalNetEnabled() (bool, error) {
 	content, err := os.ReadFile(PathRouteLocalNet)
 	if err != nil {
-		return false, fmt.Errorf("failed to read net.ipv4.conf.all.route_localnet: %v", err)
+		return false, err
 	}
 	return strings.TrimSpace(string(content)) == "1", nil
 }

--- a/pkg/sysctl/user.go
+++ b/pkg/sysctl/user.go
@@ -21,7 +21,7 @@ func MaxUserNamespaces() (int, error) {
 		if os.IsNotExist(err) {
 			return UserNamespaceNotSupported, nil
 		}
-		return 0, fmt.Errorf("failed to read user.max_user_namespaces: %w", err)
+		return 0, err
 	}
 	i, err := strconv.Atoi(strings.TrimSpace(string(content)))
 	if err != nil {


### PR DESCRIPTION
- Added function `UnprivilegedUsernsCloneEnabled` in pkg/sysctl/kernel.go
- Updated sysctl.go and print.go to include `UnprivilegedUsernsClone` field
- Introduced `KernelSysctl` struct usage in container model
- Upgraded dependency `github.com/ctrsploit/sploit-spec` to v0.6.1-rc2
- Simplified error handling in net.go and user.go