### PR TITLE
refactor: refactor vulnerability registration and extend capability m…

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -225,9 +225,9 @@ root@ctr # ./ctrsploit e ra -c "cat /etc/hostname"
 | CVE-2021-22555                                                          | :x:                | :heavy_check_mark: | :x:                 | :x:                | :x:                | :x:                |
 | CVE-2021-41091                                                          | :x:                | :heavy_check_mark: | :x:                 | :x:                | :x:                | :x:                |
 | [cve-2021-25741](./vul/cve-2021-25741)                                  | :heavy_check_mark: | :heavy_check_mark: | :x:                 | :heavy_check_mark: | :x:                | :x:                |
-| [cve-2022-39253](./vul/cve-2022-39253)                                  | :o:                | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :x:                |
 | [cve-2022-0492](./vul/cve-2022-0492)                                    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :x:                |
 | CVE-2022-0847                                                           | :x:                | :heavy_check_mark: | :x:                 | :x:                | :x:                | :x:                |
+| [cve-2022-39253](./vul/cve-2022-39253)                                  | :o:                | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :x:                |
 | CVE-2023-28642                                                          | :x:                | :x:                | :x:                 | :x:                | :x:                | :x:                |
 | [cve-2024-0132](./vul/cve-2024-0132)                                    | :o:                | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :x:                |
 | CVE-2024-21626                                                          | :x:                | :x:                | :x:                 | :x:                | :x:                | :x:                |

--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ Just execute `ctrsploit checksec` or standalone binary file `checksec` in the co
 | CVE-2021-22555                                                          | :x:                | :heavy_check_mark: | :x:                 | :x:                | :x:                | :x:                |
 | CVE-2021-41091                                                          | :x:                | :heavy_check_mark: | :x:                 | :x:                | :x:                | :x:                |
 | [cve-2021-25741](./vul/cve-2021-25741)                                  | :heavy_check_mark: | :heavy_check_mark: | :x:                 | :heavy_check_mark: | :x:                | :x:                |
-| [cve-2022-39253](./vul/cve-2022-39253)                                  | :o:                | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :x:                |
 | [cve-2022-0492](./vul/cve-2022-0492)                                    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :x:                |
 | CVE-2022-0847                                                           | :x:                | :heavy_check_mark: | :x:                 | :x:                | :x:                | :x:                |
+| [cve-2022-39253](./vul/cve-2022-39253)                                  | :o:                | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :x:                |
 | CVE-2023-28642                                                          | :x:                | :x:                | :x:                 | :x:                | :x:                | :x:                |
 | [cve-2024-0132](./vul/cve-2024-0132)                                    | :o:                | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: | :x:                |
 | CVE-2024-21626                                                          | :x:                | :x:                | :x:                 | :x:                | :x:                | :x:                |

--- a/cmd/ctrsploit/checksec/auto.go
+++ b/cmd/ctrsploit/checksec/auto.go
@@ -1,8 +1,26 @@
 package checksec
 
+//goland:noinspection GoSnakeCaseUsage
 import (
-	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/release_agent"
+	"github.com/ctrsploit/ctrsploit/vul/caps/bpf"
+	"github.com/ctrsploit/ctrsploit/vul/caps/shocker"
+	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin"
+	"github.com/ctrsploit/ctrsploit/vul/caps/sys_ptrace"
+	"github.com/ctrsploit/ctrsploit/vul/caps/sys_ptrace/pid_host"
+	cve_2016_8867 "github.com/ctrsploit/ctrsploit/vul/cve-2016-8867"
+	cve_2019_5736 "github.com/ctrsploit/ctrsploit/vul/cve-2019-5736"
+	cve_2020_15257 "github.com/ctrsploit/ctrsploit/vul/cve-2020-15257"
+	cve_2021_25741 "github.com/ctrsploit/ctrsploit/vul/cve-2021-25741"
+	cve_2022_0492 "github.com/ctrsploit/ctrsploit/vul/cve-2022-0492"
+	cve_2022_39253 "github.com/ctrsploit/ctrsploit/vul/cve-2022-39253"
+	cve_2024_0132 "github.com/ctrsploit/ctrsploit/vul/cve-2024-0132"
+	cve_2024_23650 "github.com/ctrsploit/ctrsploit/vul/cve-2024-23650"
+	cve_2025_23266 "github.com/ctrsploit/ctrsploit/vul/cve-2025-23266"
+	cve_2025_47290 "github.com/ctrsploit/ctrsploit/vul/cve-2025-47290"
+	"github.com/ctrsploit/ctrsploit/vul/naked"
 	"github.com/ctrsploit/ctrsploit/vul/namespace/net"
+	"github.com/ctrsploit/ctrsploit/vul/namespace/pid"
+	docker_sock "github.com/ctrsploit/ctrsploit/vul/shared-socket/docker-sock"
 	"github.com/ctrsploit/sploit-spec/pkg/vul"
 	"github.com/urfave/cli/v2"
 )
@@ -17,8 +35,25 @@ var Auto = &cli.Command{
 	Aliases: []string{"a"},
 	Action: func(context *cli.Context) (err error) {
 		vulnerabilities := vul.Vulnerabilities{
-			&release_agent.Vul,
+			&cve_2016_8867.Vul,
+			&cve_2019_5736.Vul,
+			&cve_2020_15257.Vul,
+			&cve_2021_25741.Vul,
+			&cve_2022_39253.Vul,
+			&cve_2022_0492.Vul,
+			&cve_2024_0132.Vul,
+			&cve_2024_23650.Vul,
+			&cve_2025_23266.Vul,
+			&cve_2025_47290.Vul,
+			&shocker.Vul,
+			&sys_admin.Vul,
+			&bpf.Vul,
+			&sys_ptrace.Vul,
+			&pid_host.Vul,
+			&naked.Vul,
 			&net.Vul,
+			&pid.Vul,
+			&docker_sock.Vul,
 		}
 		err = vulnerabilities.Check(context)
 		if err != nil {

--- a/cmd/ctrsploit/checksec/checksec.go
+++ b/cmd/ctrsploit/checksec/checksec.go
@@ -1,11 +1,11 @@
 package checksec
 
+//goland:noinspection GoSnakeCaseUsage
 import (
 	"github.com/ctrsploit/ctrsploit/cmd/ctrsploit/env"
+	"github.com/ctrsploit/ctrsploit/vul/caps/bpf"
 	"github.com/ctrsploit/ctrsploit/vul/caps/shocker"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin"
-	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/ebpf"
-	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/release_agent"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_ptrace"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_ptrace/pid_host"
 	cve_2016_8867 "github.com/ctrsploit/ctrsploit/vul/cve-2016-8867"
@@ -22,7 +22,6 @@ import (
 	"github.com/ctrsploit/ctrsploit/vul/namespace/net"
 	"github.com/ctrsploit/ctrsploit/vul/namespace/pid"
 	docker_sock "github.com/ctrsploit/ctrsploit/vul/shared-socket/docker-sock"
-	"github.com/ctrsploit/sploit-spec/pkg/app"
 	"github.com/urfave/cli/v2"
 )
 
@@ -33,24 +32,23 @@ var Command = &cli.Command{
 	Subcommands: []*cli.Command{
 		Auto,
 		env.Command,
-		app.Vul2ChecksecCmd(&net.Vul, []string{"host"}, nil),
-		cve_2025_23266.CheckSecCmd,
-		cve_2025_47290.CheckSecCmd,
+		cve_2016_8867.CheckSecCmd,
+		cve_2019_5736.CheckSecCmd,
+		cve_2020_15257.CheckSecCmd,
+		cve_2021_25741.CheckSecCmd,
+		cve_2022_0492.CheckSecCmd,
+		cve_2022_39253.CheckSecCmd,
 		cve_2024_0132.CheckSecCmd,
 		cve_2024_23650.CheckSecCmd,
-		cve_2022_39253.CheckSecCmd,
-		cve_2022_0492.CheckSecCmd,
-		cve_2021_25741.CheckSecCmd,
-		cve_2020_15257.CheckSecCmd,
-		cve_2019_5736.CheckSecCmd,
-		cve_2016_8867.CheckSecCmd,
-		naked.CheckSecCmd,
-		sys_admin.CheckSecCmd,
-		ebpf.CheckSecCmd,
-		release_agent.CheckSecCmd,
+		cve_2025_23266.CheckSecCmd,
+		cve_2025_47290.CheckSecCmd,
 		shocker.CheckSecCmd,
-		pid_host.CheckSecCmd,
+		sys_admin.CheckSecCmd,
+		bpf.CheckSecCmd,
 		sys_ptrace.CheckSecCmd,
+		pid_host.CheckSecCmd,
+		naked.CheckSecCmd,
+		net.CheckSecCmd,
 		pid.CheckSecCmd,
 		docker_sock.CheckSecCmd,
 	},

--- a/cmd/ctrsploit/exploit/exploit.go
+++ b/cmd/ctrsploit/exploit/exploit.go
@@ -1,14 +1,17 @@
 //go:build !pro
-// +build !pro
 
 package exploit
 
+//goland:noinspection GoSnakeCaseUsage
 import (
+	"github.com/ctrsploit/ctrsploit/vul/caps/bpf"
 	"github.com/ctrsploit/ctrsploit/vul/caps/shocker"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin"
+	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/ebpf"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/ebpf/bash"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/ebpf/cron"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/ebpf/execve"
+	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/ebpf/kubelet"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/release_agent"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_ptrace"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_ptrace/pid_host"
@@ -22,6 +25,7 @@ import (
 	cve_2024_23650 "github.com/ctrsploit/ctrsploit/vul/cve-2024-23650"
 	cve_2025_23266 "github.com/ctrsploit/ctrsploit/vul/cve-2025-23266"
 	cve_2025_47290 "github.com/ctrsploit/ctrsploit/vul/cve-2025-47290"
+	"github.com/ctrsploit/ctrsploit/vul/namespace/pid"
 	"github.com/ctrsploit/ctrsploit/vul/namespace/pid/proc_root"
 	docker_sock "github.com/ctrsploit/ctrsploit/vul/shared-socket/docker-sock"
 	"github.com/urfave/cli/v2"
@@ -32,32 +36,35 @@ var Command = &cli.Command{
 	Aliases: []string{"x"},
 	Usage:   "run a exploit",
 	Subcommands: []*cli.Command{
-		cgroupv1ReleaseAgentUnknownRootfs,
-		cgroupMountBypassCgroupV1ReleaseAgentCommand,
+		cve_2016_8867.ExploitCmd,
+		cve_2019_5736.ExploitCmd,
+		cve_2020_15257.ExploitCmd,
+		cve_2021_25741.ExploitCmd,
+		cve_2022_0492.ExploitCmd,
+		cve_2022_39253.ExploitCmd,
+		cve_2024_0132.ExploitCmd,
+		cve_2024_23650.ExploitCmd,
+		cve_2025_23266.ExploitCmd,
+		cve_2025_47290.ExploitCmd,
+		shocker.ExploitCmd,
+		sys_admin.ExploitCmd,
+		release_agent.ExploitCmd,
+		ebpf.ExploitCmd,
+		bash.ExploitCmd,
+		execve.ExploitCmd,
+		cron.ExploitCmd,
+		kubelet.ExploitCmd,
+		pid_host.ExploitCmd,
+		bpf.ExploitCmd,
+		sys_ptrace.ExploitCmd,
+		pid_host.ExploitCmd,
+		pid.ExploitCmd,
+		proc_root.ExploitCmd,
+		docker_sock.ExploitCmd,
 		CVE_2021_22555_Command,
 		CVE_2020_8555,
 		cve_2017_1002101_Command,
 		dirtyPipeCommand,
 		crashCommand,
-		cve_2025_23266.ExploitCmd,
-		cve_2025_47290.ExploitCmd,
-		cve_2024_0132.ExploitCmd,
-		cve_2024_23650.ExploitCmd,
-		cve_2022_39253.ExploitCmd,
-		cve_2022_0492.ExploitCmd,
-		cve_2021_25741.ExploitCmd,
-		cve_2020_15257.ExploitCmd,
-		cve_2019_5736.ExploitCmd,
-		cve_2016_8867.ExploitCmd,
-		sys_admin.ExploitCmd,
-		release_agent.ExploitCmd,
-		shocker.ExploitCmd,
-		pid_host.ExploitCmd,
-		sys_ptrace.ExploitCmd,
-		proc_root.ExploitCmd,
-		docker_sock.ExploitCmd,
-		bash.ExploitCmd,
-		execve.ExploitCmd,
-		cron.ExploitCmd,
 	},
 }

--- a/cmd/ctrsploit/vul/vul.go
+++ b/cmd/ctrsploit/vul/vul.go
@@ -1,5 +1,6 @@
 package vul
 
+//goland:noinspection GoSnakeCaseUsage
 import (
 	"github.com/ctrsploit/ctrsploit/vul/caps"
 	cve_2016_8867 "github.com/ctrsploit/ctrsploit/vul/cve-2016-8867"
@@ -23,16 +24,16 @@ var Command = &cli.Command{
 	Aliases: []string{"v"},
 	Usage:   "list vulnerabilities",
 	Subcommands: []*cli.Command{
-		cve_2025_23266.VulCmd,
-		cve_2025_47290.VulCmd,
+		cve_2016_8867.VulCmd,
+		cve_2019_5736.VulCmd,
+		cve_2020_15257.VulCmd,
+		cve_2021_25741.VulCmd,
+		cve_2022_0492.VulCmd,
+		cve_2022_39253.VulCmd,
 		cve_2024_0132.VulCmd,
 		cve_2024_23650.VulCmd,
-		cve_2022_39253.VulCmd,
-		cve_2022_0492.VulCmd,
-		cve_2021_25741.VulCmd,
-		cve_2020_15257.VulCmd,
-		cve_2019_5736.VulCmd,
-		cve_2016_8867.VulCmd,
+		cve_2025_23266.VulCmd,
+		cve_2025_47290.VulCmd,
 		naked.VulCmd,
 		caps.VulCmd,
 		namespace.VulCmd,

--- a/vul/caps/bpf/vul.go
+++ b/vul/caps/bpf/vul.go
@@ -1,20 +1,26 @@
 package bpf
 
 import (
+	"github.com/ctrsploit/ctrsploit/prerequisite/capability"
 	"github.com/ctrsploit/ctrsploit/vul/caps/sys_admin/ebpf"
+	"github.com/ctrsploit/sploit-spec/pkg/app"
 	"github.com/ctrsploit/sploit-spec/pkg/exeenv"
+	"github.com/ctrsploit/sploit-spec/pkg/prerequisite"
 	"github.com/ctrsploit/sploit-spec/pkg/vul"
 	"github.com/urfave/cli/v2"
 )
 
 var (
-	aliases = []string{"bpf"}
-	VulCmd  = &cli.Command{
+	aliases     = []string{"bpf"}
+	CheckSecCmd = getCheckSecCmd(Vul.GetName(), Vul.GetDescription(), aliases)
+	ExploitCmd  = getExploitCmd(Vul.GetName(), Vul.GetDescription(), aliases)
+	VulCmd      = &cli.Command{
 		Name:    Vul.GetName(),
 		Aliases: aliases,
 		Usage:   Vul.GetDescription(),
 		Subcommands: []*cli.Command{
-			ebpf.VulCmd,
+			getCheckSecCmd("checksec", "check vulnerability exists", []string{"c"}),
+			getExploitCmd("exploit", "run the exploit", []string{"x"}),
 		},
 	}
 )
@@ -33,6 +39,34 @@ var (
 				Check:   exeenv.InContainer,
 				Exploit: exeenv.InContainer,
 			},
+			CheckSecPrerequisites: prerequisite.Or(
+				&capability.CapSysAdminBnd,
+				&capability.CapBpfBnd,
+			),
+			ExploitablePrerequisites: prerequisite.Or(
+				&capability.CapSysAdminEff,
+				&capability.CapBpfEff,
+			),
 		},
 	}
 )
+
+func getCheckSecCmd(name, usage string, aliases []string) (cmd *cli.Command) {
+	cmd = app.Vul2ChecksecCmd(&Vul, aliases, nil)
+	cmd.Name = name
+	cmd.Usage = usage
+	cmd.Aliases = aliases
+	return
+}
+
+func getExploitCmd(name, usage string, aliases []string) (cmd *cli.Command) {
+	return &cli.Command{
+		Name:    name,
+		Usage:   usage,
+		Aliases: aliases,
+		Subcommands: []*cli.Command{
+			// TODO: add more exploit methods
+			ebpf.GetExploitCmd("ebpf", "exploit via eBPF", nil),
+		},
+	}
+}

--- a/vul/caps/shocker/shocker.go
+++ b/vul/caps/shocker/shocker.go
@@ -9,42 +9,9 @@ import (
 	"syscall"
 
 	"github.com/ctrsploit/ctrsploit/pkg/util"
-	"github.com/ctrsploit/ctrsploit/prerequisite/capability"
-	"github.com/ctrsploit/sploit-spec/pkg/exeenv"
-	"github.com/ctrsploit/sploit-spec/pkg/vul"
 	"github.com/ssst0n3/awesome_libs/awesome_error"
-	"github.com/urfave/cli/v2"
 	"golang.org/x/sys/unix"
 )
-
-type Vulnerability struct {
-	vul.BaseVulnerability
-}
-
-var Shocker = Vulnerability{
-	BaseVulnerability: vul.BaseVulnerability{
-		Name:        "shocker",
-		Description: "Container escape with CAP_DAC_READ_SEARCH, alias shocker, found by Sebastian Krahmer (stealth) in 2014.",
-		Level:       vul.LevelHigh,
-		ExeEnv: exeenv.ExeEnv{
-			Env:     exeenv.InContainer,
-			Check:   exeenv.InContainer,
-			Exploit: exeenv.InContainer,
-		},
-		CheckSecPrerequisites:    &capability.CapDacReadSearchBnd,
-		ExploitablePrerequisites: &capability.CapDacReadSearchEff,
-	},
-}
-
-func (v *Vulnerability) Exploit(context *cli.Context) (err error) {
-	err = v.BaseVulnerability.Exploit(context)
-	if err != nil {
-		return
-	}
-	inode := context.Int("inode")
-	ref := context.String("ref")
-	return Exploit(inode, ref, os.Stdin, os.Stdout, os.Stderr)
-}
 
 func Exploit(inode int, ref string, i io.Reader, o, e io.Writer) (err error) {
 	fd, err := GetFd(inode, ref)
@@ -83,7 +50,6 @@ func GetFd(inode int, ref string) (fd int, err error) {
 	}
 	defer syscall.Close(hostReference)
 	inodeBytes := make([]byte, 8)
-	// 将 inode 转换为小端序的字节数组
 	binary.LittleEndian.PutUint64(inodeBytes, uint64(inode))
 	handle := unix.NewFileHandle(1, inodeBytes)
 	fd, err = unix.OpenByHandleAt(hostReference, handle, unix.O_RDONLY)

--- a/vul/caps/shocker/vul.go
+++ b/vul/caps/shocker/vul.go
@@ -1,7 +1,12 @@
 package shocker
 
 import (
+	"os"
+
+	"github.com/ctrsploit/ctrsploit/prerequisite/capability"
 	"github.com/ctrsploit/sploit-spec/pkg/app"
+	"github.com/ctrsploit/sploit-spec/pkg/exeenv"
+	"github.com/ctrsploit/sploit-spec/pkg/vul"
 	"github.com/urfave/cli/v2"
 )
 
@@ -22,7 +27,36 @@ var (
 			Value:       "/etc/hosts",
 		},
 	}
-	ExploitCmd  = app.Vul2ExploitCmd(&Shocker, aliases, flagsExploit, true)
-	CheckSecCmd = app.Vul2ChecksecCmd(&Shocker, aliases, nil)
-	VulCmd      = app.Vul2VulCmd(&Shocker, aliases, nil, flagsExploit, true)
+	ExploitCmd  = app.Vul2ExploitCmd(&Vul, aliases, flagsExploit, true)
+	CheckSecCmd = app.Vul2ChecksecCmd(&Vul, aliases, nil)
+	VulCmd      = app.Vul2VulCmd(&Vul, aliases, nil, flagsExploit, true)
 )
+
+type vulnerability struct {
+	vul.BaseVulnerability
+}
+
+var Vul = vulnerability{
+	BaseVulnerability: vul.BaseVulnerability{
+		Name:        "shocker",
+		Description: "Container escape with CAP_DAC_READ_SEARCH, alias shocker, found by Sebastian Krahmer (stealth) in 2014.",
+		Level:       vul.LevelHigh,
+		ExeEnv: exeenv.ExeEnv{
+			Env:     exeenv.InContainer,
+			Check:   exeenv.InContainer,
+			Exploit: exeenv.InContainer,
+		},
+		CheckSecPrerequisites:    &capability.CapDacReadSearchBnd,
+		ExploitablePrerequisites: &capability.CapDacReadSearchEff,
+	},
+}
+
+func (v *vulnerability) Exploit(context *cli.Context) (err error) {
+	err = v.BaseVulnerability.Exploit(context)
+	if err != nil {
+		return
+	}
+	inode := context.Int("inode")
+	ref := context.String("ref")
+	return Exploit(inode, ref, os.Stdin, os.Stdout, os.Stderr)
+}

--- a/vul/namespace/net/vul.go
+++ b/vul/namespace/net/vul.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	aliases = []string{"net"}
-	VulCmd  = &cli.Command{
+	aliases     = []string{"net"}
+	CheckSecCmd = getCheckSecCmd(Vul.GetName(), Vul.GetDescription(), aliases)
+	VulCmd      = &cli.Command{
 		Name:    Vul.GetName(),
 		Aliases: aliases,
 		Usage:   Vul.GetDescription(),

--- a/vul/namespace/pid/vul.go
+++ b/vul/namespace/pid/vul.go
@@ -13,6 +13,7 @@ import (
 var (
 	aliases     = []string{"pid"}
 	CheckSecCmd = getCheckSecCmd(Vul.Name, Vul.Description, aliases)
+	ExploitCmd  = getExploitCmd(Vul.Name, Vul.Description, aliases)
 	VulCmd      = &cli.Command{
 		Name:    Vul.GetName(),
 		Aliases: aliases,

--- a/vul/shared-socket/vul.go
+++ b/vul/shared-socket/vul.go
@@ -19,6 +19,10 @@ var (
 	}
 )
 
+type vulnerability struct {
+	vul.BaseVulnerability
+}
+
 var (
 	Vul = vulnerability{
 		BaseVulnerability: vul.BaseVulnerability{
@@ -33,7 +37,3 @@ var (
 		},
 	}
 )
-
-type vulnerability struct {
-	vul.BaseVulnerability
-}


### PR DESCRIPTION
…odules

- Reorder and standardize vulnerability registration in checksec, exploit, and vul packages
- Add new imports for BPF, shocker, sys_ptrace, and namespace PID modules
- Introduce helper functions for generating checksec and exploit commands
- Refactor shocker vulnerability definition and move exploit logic to vul.go
- Add missing ExploitCmd and CheckSecCmd to BPF and PID modules
- Adjust README tables to reflect CVE ordering