### PR TITLE
feat(env/kernel): add rlimit support and extend sysctl with pid_max

### DIFF
--- a/cmd/ctrsploit/env/env.go
+++ b/cmd/ctrsploit/env/env.go
@@ -21,6 +21,8 @@ var Command = &cli.Command{
 		Selinux,
 		Fdisk,
 		Kernel,
+		Sysctl,
+		Rlimit,
 		Namespace,
 		DockerVersion,
 		Upload,

--- a/cmd/ctrsploit/env/rlimit.go
+++ b/cmd/ctrsploit/env/rlimit.go
@@ -1,0 +1,18 @@
+package env
+
+import (
+	"github.com/ctrsploit/ctrsploit/env/kernel/rlimit"
+	"github.com/urfave/cli/v2"
+)
+
+var Rlimit = &cli.Command{
+	Name:  "rlimit",
+	Usage: "",
+	Action: func(c *cli.Context) error {
+		err := rlimit.Print()
+		if err != nil {
+			return err
+		}
+		return nil
+	},
+}

--- a/env/kernel/kernel.go
+++ b/env/kernel/kernel.go
@@ -1,21 +1,26 @@
 package kernel
 
 import (
+	"github.com/ctrsploit/ctrsploit/env/kernel/rlimit"
 	"github.com/ctrsploit/ctrsploit/env/kernel/sysctl"
 	"github.com/ctrsploit/ctrsploit/pkg/kernel"
-	"github.com/ctrsploit/sploit-spec/pkg/env/container"
+	spec "github.com/ctrsploit/sploit-spec/pkg/env/container/kernel"
 	"github.com/ssst0n3/awesome_libs/awesome_error"
 )
 
 const CommandName = "kernel"
 
-func Kernel() (k container.Kernel, err error) {
+func Kernel() (k spec.Kernel, err error) {
 	k.CompiledDate, err = kernel.GetCompiledDate()
 	if err != nil {
 		awesome_error.CheckWarning(err)
 		return
 	}
 	k.Sysctl, err = sysctl.Sysctl()
+	if err != nil {
+		return
+	}
+	k.Rlimit, err = rlimit.Rlimit()
 	if err != nil {
 		return
 	}

--- a/env/kernel/print.go
+++ b/env/kernel/print.go
@@ -1,8 +1,9 @@
 package kernel
 
 import (
+	"github.com/ctrsploit/ctrsploit/env/kernel/rlimit"
 	"github.com/ctrsploit/ctrsploit/env/kernel/sysctl"
-	"github.com/ctrsploit/sploit-spec/pkg/env/container"
+	"github.com/ctrsploit/sploit-spec/pkg/env/container/kernel"
 	"github.com/ctrsploit/sploit-spec/pkg/printer"
 	"github.com/ctrsploit/sploit-spec/pkg/result"
 	"github.com/ctrsploit/sploit-spec/pkg/result/item"
@@ -11,10 +12,11 @@ import (
 type Result struct {
 	Name         result.Title
 	CompiledDate item.Short `json:"compiled_date"`
-	sysctl.Result
+	Sysctl       sysctl.Result
+	Rlimit       rlimit.Result
 }
 
-func Human(machine container.Kernel) (human Result) {
+func Human(machine kernel.Kernel) (human Result) {
 	human = Result{
 		Name: result.Title{
 			Name: "Kernel",
@@ -24,7 +26,8 @@ func Human(machine container.Kernel) (human Result) {
 			Description: "The date when the kernel was compiled.",
 			Result:      machine.CompiledDate.String(),
 		},
-		Result: sysctl.Human(machine.Sysctl),
+		Sysctl: sysctl.Human(machine.Sysctl),
+		Rlimit: rlimit.Human(machine.Rlimit),
 	}
 	return
 }

--- a/env/kernel/rlimit/print.go
+++ b/env/kernel/rlimit/print.go
@@ -1,0 +1,132 @@
+package rlimit
+
+import (
+	"fmt"
+
+	"github.com/ctrsploit/ctrsploit/pkg/rlimit"
+	spec "github.com/ctrsploit/sploit-spec/pkg/env/container/kernel/rlimit"
+	"github.com/ctrsploit/sploit-spec/pkg/printer"
+	"github.com/ctrsploit/sploit-spec/pkg/result"
+	"github.com/ctrsploit/sploit-spec/pkg/result/item"
+)
+
+type Result struct {
+	Name       result.Title
+	Core       item.Short
+	Cpu        item.Short
+	Data       item.Short
+	Fsize      item.Short
+	Locks      item.Short
+	Msgqueue   item.Short
+	Nice       item.Short
+	Rtprio     item.Short
+	Rttime     item.Short
+	Sigpending item.Short
+	Stack      item.Short
+	As         item.Short
+	Memlock    item.Short
+	Nofile     item.Short
+	Nproc      item.Short
+	Rss        item.Short
+}
+
+func Human(machine spec.Rlimit) Result {
+	return Result{
+		Name: result.Title{
+			Name: "Rlimit",
+		},
+		Core: item.Short{
+			Name:        "core",
+			Description: "max core file size",
+			Result:      rlimit.Resource(machine.Core).String(),
+		},
+		Cpu: item.Short{
+			Name:        "cpu",
+			Description: "CPU time in seconds",
+			Result:      rlimit.Resource(machine.Cpu).String(),
+		},
+		Data: item.Short{
+			Name:        "data",
+			Description: "max data size",
+			Result:      rlimit.Resource(machine.Data).String(),
+		},
+		Fsize: item.Short{
+			Name:        "fsize",
+			Description: "max file size",
+			Result:      rlimit.Resource(machine.Fsize).String(),
+		},
+		Locks: item.Short{
+			Name:        "locks",
+			Description: "max number of file locks",
+			Result:      rlimit.Resource(machine.Locks).String(),
+		},
+		Msgqueue: item.Short{
+			Name:        "msgqueue",
+			Description: "max bytes in POSIX message queues",
+			Result:      rlimit.Resource(machine.Msgqueue).String(),
+		},
+		Nice: item.Short{
+			Name:        "nice",
+			Description: "max nice priority",
+			Result:      rlimit.Resource(machine.Nice).String(),
+		},
+		Rtprio: item.Short{
+			Name:        "rtprio",
+			Description: "max real-time priority",
+			Result:      rlimit.Resource(machine.Rtprio).String(),
+		},
+		Rttime: item.Short{
+			Name:        "rttime",
+			Description: "timeout for real-time tasks",
+			Result:      rlimit.Resource(machine.Rttime).String(),
+		},
+		Sigpending: item.Short{
+			Name:        "sigpending",
+			Description: "max number of pending signals",
+			Result:      rlimit.Resource(machine.Sigpending).String(),
+		},
+		Stack: item.Short{
+			Name:        "stack",
+			Description: "max stack size",
+			Result:      rlimit.Resource(machine.Stack).String(),
+		},
+		As: item.Short{
+			Name:        "as",
+			Description: "address space (virtual memory)",
+			Result:      rlimit.Resource(machine.As).String(),
+		},
+		Memlock: item.Short{
+			Name:        "memlock",
+			Description: "max locked-in-memory address space",
+			Result:      rlimit.Resource(machine.Memlock).String(),
+		},
+		Nofile: item.Short{
+			Name:        "nofile",
+			Description: "max number of open files",
+			Result:      rlimit.Resource(machine.Nofile).String(),
+		},
+		Nproc: item.Short{
+			Name:        "nproc",
+			Description: "max number of processes",
+			Result:      rlimit.Resource(machine.Nproc).String(),
+		},
+		Rss: item.Short{
+			Name:        "rss",
+			Description: "max resident set size",
+			Result:      rlimit.Resource(machine.Rss).String(),
+		},
+	}
+}
+
+func Print() (err error) {
+	r, err := Rlimit()
+	if err != nil {
+		return err
+	}
+	u := result.Union{
+		Machine: r,
+		Human:   Human(r),
+	}
+	fmt.Println(printer.Printer.Print(u))
+	return
+}

--- a/env/kernel/rlimit/rlimit.go
+++ b/env/kernel/rlimit/rlimit.go
@@ -1,0 +1,10 @@
+package rlimit
+
+import (
+	"github.com/ctrsploit/ctrsploit/pkg/rlimit"
+	spec "github.com/ctrsploit/sploit-spec/pkg/env/container/kernel/rlimit"
+)
+
+func Rlimit() (spec.Rlimit, error) {
+	return rlimit.GetAll()
+}

--- a/env/kernel/sysctl/print.go
+++ b/env/kernel/sysctl/print.go
@@ -3,7 +3,7 @@ package sysctl
 import (
 	"fmt"
 
-	"github.com/ctrsploit/sploit-spec/pkg/env/container"
+	spec "github.com/ctrsploit/sploit-spec/pkg/env/container/kernel/sysctl"
 	"github.com/ctrsploit/sploit-spec/pkg/printer"
 	"github.com/ctrsploit/sploit-spec/pkg/result"
 	"github.com/ctrsploit/sploit-spec/pkg/result/item"
@@ -14,9 +14,10 @@ type Result struct {
 	RouteLocalNet           item.Bool  `json:"route_localnet"`
 	MaxUserNamespaces       item.Short `json:"max_user_namespaces"`
 	UnprivilegedUsernsClone item.Bool  `json:"unprivileged_userns_clone"`
+	PidMax                  item.Short `json:"pid_max"`
 }
 
-func Human(machine container.Sysctl) (human Result) {
+func Human(machine spec.Sysctl) (human Result) {
 	human = Result{
 		Name: result.Title{
 			Name: "Sysctl",
@@ -28,13 +29,18 @@ func Human(machine container.Sysctl) (human Result) {
 		},
 		MaxUserNamespaces: item.Short{
 			Name:        "user.max_user_namespaces",
-			Description: "",
+			Description: "Specifies the maximum number of user namespaces that may exist on the system.",
 			Result:      fmt.Sprintf("%d", machine.MaxUserNamespaces),
 		},
 		UnprivilegedUsernsClone: item.Bool{
 			Name:        "kernel.unprivileged_userns_clone",
-			Description: "allow unprivileged process create user namespace",
+			Description: "Allow unprivileged process create user namespace",
 			Result:      machine.UnprivilegedUsernsClone,
+		},
+		PidMax: item.Short{
+			Name:        "kernel.pid_max",
+			Description: "Sets the maximum PID value, controlling how many processes the system can run concurrently.",
+			Result:      fmt.Sprintf("%d", machine.PidMax),
 		},
 	}
 	return

--- a/env/kernel/sysctl/sysctl.go
+++ b/env/kernel/sysctl/sysctl.go
@@ -2,13 +2,13 @@ package sysctl
 
 import (
 	"github.com/ctrsploit/ctrsploit/pkg/sysctl"
-	"github.com/ctrsploit/sploit-spec/pkg/env/container"
+	spec "github.com/ctrsploit/sploit-spec/pkg/env/container/kernel/sysctl"
 	"github.com/ssst0n3/awesome_libs/awesome_error"
 )
 
 const CommandName = "sysctl"
 
-func Sysctl() (s container.Sysctl, err error) {
+func Sysctl() (s spec.Sysctl, err error) {
 	s.RouteLocalNet, err = sysctl.RouteLocalNetEnabled()
 	if err != nil {
 		awesome_error.CheckWarning(err)
@@ -20,6 +20,10 @@ func Sysctl() (s container.Sysctl, err error) {
 		return
 	}
 	s.UnprivilegedUsernsClone, err = sysctl.UnprivilegedUsernsCloneEnabled()
+	if err != nil {
+		return
+	}
+	s.PidMax, err = sysctl.PidMax()
 	if err != nil {
 		awesome_error.CheckWarning(err)
 		return

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containerd/ttrpc v1.2.7
 	github.com/containerd/typeurl v1.0.2
 	github.com/coreos/go-iptables v0.8.0
-	github.com/ctrsploit/sploit-spec v0.7.0-rc4
+	github.com/ctrsploit/sploit-spec v0.7.1-rc4
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/docker v28.4.0+incompatible
 	github.com/go-git/go-git/v6 v6.0.0-20250906064640-2917a7134436

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/ctrsploit/sploit-spec v0.7.0-rc4 h1:vLO/aGIjE6CjM0899VkFImJfczJV3e08a6X2JtvgLvQ=
-github.com/ctrsploit/sploit-spec v0.7.0-rc4/go.mod h1:8SEHnTOBTwXdgp/9LV6ZwDPXx5B9pQOJuf0X5w7qd7Q=
+github.com/ctrsploit/sploit-spec v0.7.1-rc4 h1:j2QJ6JmvUY/sA9uXHFwyZIDZGyKLGKfDvvwujveir24=
+github.com/ctrsploit/sploit-spec v0.7.1-rc4/go.mod h1:8SEHnTOBTwXdgp/9LV6ZwDPXx5B9pQOJuf0X5w7qd7Q=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/rlimit/rlimit.go
+++ b/pkg/rlimit/rlimit.go
@@ -1,0 +1,43 @@
+package rlimit
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/ctrsploit/sploit-spec/pkg/env/container/kernel/rlimit"
+	"golang.org/x/sys/unix"
+)
+
+type Resource unix.Rlimit
+
+func (r Resource) String() string {
+	format := func(v uint64) string {
+		if v == unix.RLIM_INFINITY {
+			return "unlimited"
+		}
+		return fmt.Sprintf("%d", v)
+	}
+
+	return fmt.Sprintf("soft:%s, hard:%s", format(r.Cur), format(r.Max))
+}
+
+func GetAll() (rlimit.Rlimit, error) {
+	r := rlimit.Rlimit{}
+	v := reflect.ValueOf(&r).Elem()
+
+	for name, typ := range rlimit.MapNameToType {
+		var resource unix.Rlimit
+		if err := unix.Getrlimit(typ, &resource); err != nil {
+			return r, fmt.Errorf("failed to get rlimit for %s: %w", name, err)
+		}
+		field := v.FieldByNameFunc(func(f string) bool {
+			return strings.EqualFold(f, name)
+		})
+		if field.IsValid() && field.CanSet() {
+			field.Set(reflect.ValueOf(resource))
+		}
+	}
+
+	return r, nil
+}

--- a/pkg/rlimit/rlimit_test.go
+++ b/pkg/rlimit/rlimit_test.go
@@ -1,0 +1,14 @@
+package rlimit
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAll(t *testing.T) {
+	rlimit, err := GetAll()
+	assert.NoError(t, err)
+	spew.Dump(rlimit)
+}

--- a/pkg/sysctl/kernel.go
+++ b/pkg/sysctl/kernel.go
@@ -1,18 +1,40 @@
 package sysctl
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
+
+	"github.com/ctrsploit/sploit-spec/pkg/log"
 )
 
 const (
 	PathUnprivilegedUsernsClone = "/proc/sys/kernel/unprivileged_userns_clone"
+	PathPidMax                  = "/proc/sys/kernel/pid_max"
 )
 
 func UnprivilegedUsernsCloneEnabled() (bool, error) {
 	content, err := os.ReadFile(PathUnprivilegedUsernsClone)
 	if err != nil {
+		if os.IsNotExist(err) {
+			log.Logger.Warnf("%s does not exist, assuming unprivileged user namespaces are enabled", PathUnprivilegedUsernsClone)
+			// Assume unprivileged user namespaces are enabled if the sysctl does not exist
+			return true, nil
+		}
 		return false, err
 	}
 	return strings.TrimSpace(string(content)) == "1", nil
+}
+
+func PidMax() (int, error) {
+	content, err := os.ReadFile(PathPidMax)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read max pid: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(content)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse max pid: %w", err)
+	}
+	return pid, nil
 }


### PR DESCRIPTION
- Introduced rlimit module to retrieve and display process resource limits.
- Added new CLI command `rlimit` under env commands.
- Kernel module now includes rlimit information in result output.
- Extended sysctl support to include kernel.pid_max parameter.
- Updated sploit-spec dependency to v0.7.1-rc4.