### PR TITLE
feat(maskedPath): export Path field and update related references

### DIFF
--- a/prerequisite/maskedPath/masked-path.go
+++ b/prerequisite/maskedPath/masked-path.go
@@ -11,24 +11,24 @@ import (
 
 type Masked struct {
 	prerequisite.BasePrerequisite
-	path string
+	Path string
 }
 
-// Check if the given path is masked (i.e., mounted as /dev/null).
+// Check if the given Path is masked (i.e., mounted as /dev/null).
 // returns true if masked
-// returns false if not masked or path not exists.
+// returns false if not masked or Path not exists.
 func (p *Masked) Check() (bool, error) {
 	return p.CheckTemplate(func() {
-		exists, _ := internal.CheckPathExists(p.path)
+		exists, _ := internal.CheckPathExists(p.Path)
 		if !exists {
 			return
 		}
-		info, err := mountinfo.GetMountByMountpoint(p.path)
+		info, err := mountinfo.GetMountByMountpoint(p.Path)
 		if err != nil {
 			if strings.Contains(err.Error(), mountinfo.ErrMountPointNotFound) {
 				return
 			} else {
-				p.Err = p.WrapErr(fmt.Errorf("getting mountpoint of: %s, %w", p.path, err))
+				p.Err = p.WrapErr(fmt.Errorf("getting mountpoint of: %s, %w", p.Path, err))
 			}
 		}
 		if info.Root == "/dev/null" {


### PR DESCRIPTION
Changed the `path` field in the `Masked` struct to `Path` for export. Updated all corresponding references and comments to use the new field name.