### PR TITLE
feat(sysctl): support route_localnet checking across all network inte…

### DIFF
--- a/pkg/sysctl/net.go
+++ b/pkg/sysctl/net.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	PathRouteLocalNet = "/proc/sys/net/ipv4/conf/all/route_localnet"
+	PatternRouteLocalNet = "/proc/sys/net/ipv4/conf/*/route_localnet"
 )
 
 /*
@@ -23,11 +23,23 @@ route_localnet - BOOLEAN
 https://github.com/kubernetes/kubernetes/issues/90259
 */
 func RouteLocalNetEnabled() (bool, error) {
-	content, err := os.ReadFile(PathRouteLocalNet)
+	filePaths, err := filepath.Glob(PatternRouteLocalNet)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to glob route_localnet: %w", err)
 	}
-	return strings.TrimSpace(string(content)) == "1", nil
+	if len(filePaths) == 0 {
+		return false, fmt.Errorf("no route_localnet found")
+	}
+	for _, path := range filePaths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return false, fmt.Errorf("failed to read %s: %w", path, err)
+		}
+		if strings.TrimSpace(string(content)) == "1" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // RpFilterMode reads all rp_filter settings from /proc/sys/net/ipv4/conf/*/rp_filter

--- a/prerequisite/sysctl/net/route_localnet.go
+++ b/prerequisite/sysctl/net/route_localnet.go
@@ -29,7 +29,7 @@ var (
 	RouteLocalNetEnabled = RouteLocalnet{
 		BasePrerequisite: prerequisite.BasePrerequisite{
 			Name:   "route_localnet enabled",
-			Info:   "net.ipv4.conf.all.route_localnet = 1",
+			Info:   "net.ipv4.conf.*.route_localnet = 1",
 			ExeEnv: exeenv.InHost | exeenv.InContainer,
 		},
 		Expected: true,


### PR DESCRIPTION
…rfaces

Replace fixed path "/proc/sys/net/ipv4/conf/all/route_localnet" with a glob pattern "/proc/sys/net/ipv4/conf/*/route_localnet" to check route_localnet settings for each network interface. Update prerequisite info to reflect this change.