### PR TITLE
fix(cgroup,v1): correct inaccurate host top-level subsystem detection

### DIFF
--- a/pkg/cgroup/v1/subsystem.go
+++ b/pkg/cgroup/v1/subsystem.go
@@ -76,7 +76,7 @@ func (c CgroupV1) ListSubsystemsDeprecated(procCgroupPath string) (subsystems ma
 }
 
 /*
-IsTopDeprecated fails in the sub cgroup ns
+IsTopQuick fails in the sub cgroup ns
 root@73313224d1ef:/# unshare -UrCm /bin/bash
 root@73313224d1ef:/# cat /proc/1/cgroup
 12:freezer:/
@@ -93,7 +93,7 @@ root@73313224d1ef:/# cat /proc/1/cgroup
 1:name=systemd:/
 0::/
 */
-func (c CgroupV1) IsTopDeprecated(subsystemPath string) (top bool) {
+func (c CgroupV1) IsTopQuick(subsystemPath string) (top bool) {
 	return subsystemPath == "/"
 }
 
@@ -104,6 +104,10 @@ func ListTopLevelSubSystem() (topLevelSubSystems []string, err error) {
 		return nil, fmt.Errorf("ListTopLevelSubSystem: failed to list sub systems: %w", err)
 	}
 	for _, subsystemName := range subsystemsSupport {
+		// add this to be more accurate on the host
+		if !c.IsTopQuick(subsystemName) {
+			continue
+		}
 		is, err := c.IsTop(DefaultMountPoint, subsystemName)
 		if err != nil {
 			return nil, fmt.Errorf("ListTopLevelSubSystem: failed to list sub system %s: %w", subsystemName, err)

--- a/prerequisite/kernel/cve-2022-0492/0492_ctr.go
+++ b/prerequisite/kernel/cve-2022-0492/0492_ctr.go
@@ -9,6 +9,7 @@ import (
 
 	"errors"
 
+	"github.com/ctrsploit/ctrsploit/internal"
 	"github.com/ctrsploit/ctrsploit/pkg/mount"
 	"github.com/ctrsploit/sploit-spec/pkg/exeenv"
 	"github.com/ctrsploit/sploit-spec/pkg/log"
@@ -94,6 +95,9 @@ func testWriteReleaseAgent() {
 	}()
 	// write
 	pathReleaseAgent := filepath.Join(dirCgroup, "release_agent")
+	if exists, _ := internal.CheckPathExists(pathReleaseAgent); !exists {
+		awesome_error.CheckFatal(fmt.Errorf("path %s not found", pathReleaseAgent))
+	}
 	log.Logger.Infof("echo 1 > %s", pathReleaseAgent)
 	err = os.WriteFile(pathReleaseAgent, []byte("1"), 0644)
 	awesome_error.CheckFatal(err)


### PR DESCRIPTION
- Replaced IsTopDeprecated with IsTopQuick for clearer top-level identification.
- Added IsTopQuick check in ListTopLevelSubSystem() to more accurately filter top-level subsystems on the host.
- Added an existence check for release_agent in CVE-2022-0492 test to prevent missing path errors during validation.