### PR TITLE
fix(pkg/cgroup/v1): correct subsystem listing and add E2E validation …

### DIFF
--- a/pkg/cgroup/v1/e2e.yml
+++ b/pkg/cgroup/v1/e2e.yml
@@ -1,0 +1,16 @@
+name: pkg/cgroup/v1
+test_envs:
+  - name: cve-2022-0492-host
+    remote_host: cve-2022-0492
+    kind: dqd
+    dqd_dir: vul/cve-2022-0492
+    pkg: github.com/ctrsploit/ctrsploit/pkg/cgroup/v1
+    cmd: TEST_ENV=cve-2022-0492-host /ctrsploit.test -test.v -test.run "^TestE2E_ListTopLevelSubSystem$"
+  - name: cve-2022-0492-ctr
+    remote_host: cve-2022-0492
+    kind: dqd
+    dqd_dir: vul/cve-2022-0492
+    pkg: github.com/ctrsploit/ctrsploit/pkg/cgroup/v1
+    cmd: docker run -u nobody -v /ctrsploit.test:/ctrsploit.test
+      --env TEST_ENV=cve-2022-0492-ctr busybox:latest
+      /ctrsploit.test -test.v -test.run '^TestE2E'

--- a/pkg/cgroup/v1/subsystem.go
+++ b/pkg/cgroup/v1/subsystem.go
@@ -58,7 +58,7 @@ func (c CgroupV1) ListSubsystems(mountpoint string) (subsystems []string, err er
 	return
 }
 
-func (c CgroupV1) ListSubsystemsDeprecated(procCgroupPath string) (subsystems map[string]string, err error) {
+func (c CgroupV1) ListSubsystemsQuick(procCgroupPath string) (subsystems map[string]string, err error) {
 	subsystems, err = cgroups.ParseCgroupFile(procCgroupPath)
 	if err != nil {
 		awesome_error.CheckErr(err)
@@ -97,17 +97,27 @@ func (c CgroupV1) IsTopQuick(subsystemPath string) (top bool) {
 	return subsystemPath == "/"
 }
 
+func listTopLevelSubSystemQuick() (topLevelSubSystems []string, err error) {
+	var c CgroupV1
+	subsystemsSupport, err := c.ListSubsystemsQuick("/proc/self/cgroup")
+	if err != nil {
+		return nil, fmt.Errorf("ListSubsystemsQuick() failed: %w", err)
+	}
+	for name, path := range subsystemsSupport {
+		if c.IsTopQuick(path) {
+			topLevelSubSystems = append(topLevelSubSystems, name)
+		}
+	}
+	return
+}
+
 func ListTopLevelSubSystem() (topLevelSubSystems []string, err error) {
 	var c CgroupV1
-	subsystemsSupport, err := c.ListSubsystems(DefaultMountPoint)
+	subsystems, err := listTopLevelSubSystemQuick()
 	if err != nil {
-		return nil, fmt.Errorf("ListTopLevelSubSystem: failed to list sub systems: %w", err)
+		return nil, fmt.Errorf("listTopLevelSubSystemQuick: failed to list sub systems: %w", err)
 	}
-	for _, subsystemName := range subsystemsSupport {
-		// add this to be more accurate on the host
-		if !c.IsTopQuick(subsystemName) {
-			continue
-		}
+	for _, subsystemName := range subsystems {
 		is, err := c.IsTop(DefaultMountPoint, subsystemName)
 		if err != nil {
 			return nil, fmt.Errorf("ListTopLevelSubSystem: failed to list sub system %s: %w", subsystemName, err)

--- a/pkg/cgroup/v1/subsystem_test.go
+++ b/pkg/cgroup/v1/subsystem_test.go
@@ -2,13 +2,37 @@ package v1
 
 import (
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestE2E_ListTopLevelSubSystem(t *testing.T) {
+	testEnv := os.Getenv("TEST_ENV")
+	tests := map[string]struct {
+		expected []string
+	}{
+		"cve-2022-0492-host": {
+			expected: []string{"perf_event", "rdma", "hugetlb", "cpuset", "freezer", "net_cls", "net_prio"},
+		},
+		"cve-2022-0492-ctr": {
+			expected: []string{"rdma"},
+		},
+	}
+	test, ok := tests[testEnv]
+	if !ok {
+		t.Skipf("Skipping test for unsupported environment: %s", testEnv)
+	}
+	t.Run(testEnv, func(t *testing.T) {
+		subsystems, err := ListTopLevelSubSystem()
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, test.expected, subsystems)
+	})
+}
 
 func TestIsTopOld(t *testing.T) {
 	type args struct {
@@ -178,11 +202,11 @@ func TestCgroupV1_ListSubsystemsOld(t *testing.T) {
 			}
 			gotSubsystems, err := c.ListSubsystems(tt.args.mountpoint)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ListSubsystemsDeprecated() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ListSubsystemsQuick() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(gotSubsystems, tt.wantSubsystems) {
-				t.Errorf("ListSubsystemsDeprecated() gotSubsystems = %v, want %v", gotSubsystems, tt.wantSubsystems)
+				t.Errorf("ListSubsystemsQuick() gotSubsystems = %v, want %v", gotSubsystems, tt.wantSubsystems)
 			}
 			if tt.cleanEnvFunc != nil {
 				assert.NoError(t, tt.cleanEnvFunc(tt.args.mountpoint))
@@ -270,13 +294,13 @@ func TestCgroupV1_ListSubsystems(t *testing.T) {
 			defer func() {
 				assert.NoError(t, os.Remove(procCgroupPath))
 			}()
-			gotSubsystems, err := c.ListSubsystemsDeprecated(procCgroupPath)
+			gotSubsystems, err := c.ListSubsystemsQuick(procCgroupPath)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ListSubsystemsDeprecated() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ListSubsystemsQuick() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(gotSubsystems, tt.wantSubsystems) {
-				t.Errorf("ListSubsystemsDeprecated() gotSubsystems = %v, want %v", gotSubsystems, tt.wantSubsystems)
+				t.Errorf("ListSubsystemsQuick() gotSubsystems = %v, want %v", gotSubsystems, tt.wantSubsystems)
 			}
 		})
 	}


### PR DESCRIPTION
…for Quick methods

- Fix the subsystem listing logic by introducing `ListSubsystemsQuick` to replace deprecated method.
- Add `listTopLevelSubSystemQuick` to ensure accurate detection of top-level subsystems.
- Add `TestE2E_ListTopLevelSubSystem` for host and container verification.
- Add `pkg/cgroup/v1/e2e.yml` for E2E test environment settings.
- Update existing tests and messages to align with the new Quick methods.