### PR TITLE
fix(cgroup/v1): use /proc/1/cgroup instead of /proc/self/cgroup to de…

### DIFF
--- a/pkg/cgroup/v1/subsystem.go
+++ b/pkg/cgroup/v1/subsystem.go
@@ -172,9 +172,44 @@ func (c CgroupV1) IsTopQuick(subsystemPath string) (top bool) {
 	return subsystemPath == "/"
 }
 
+/*
+use /proc/1/cgroup instead of /proc/self/cgroup
+because when execute in host, /proc/self/cgroup in sub cgroup ns shows top level sub system, but actually not.
+and in host, we can use /proc/1/cgroup to shows real levels.
+
+root@cve-2022-0492:~# unshare -UrCm
+root@cve-2022-0492:~# cat /proc/1/cgroup
+12:perf_event:/
+11:hugetlb:/
+10:net_cls,net_prio:/
+9:rdma:/
+8:pids:/../../..
+7:devices:/..
+6:cpu,cpuacct:/..
+5:memory:/../../..
+4:blkio:/..
+3:cpuset:/
+2:freezer:/
+1:name=systemd:/../../../init.scope
+0::/../../../init.scope
+root@cve-2022-0492:~# cat /proc/self/cgroup
+12:perf_event:/
+11:hugetlb:/
+10:net_cls,net_prio:/
+9:rdma:/
+8:pids:/
+7:devices:/
+6:cpu,cpuacct:/
+5:memory:/
+4:blkio:/
+3:cpuset:/
+2:freezer:/
+1:name=systemd:/
+0::/
+*/
 func listTopLevelSubSystemQuick() (topLevelSubSystems []string, err error) {
 	var c CgroupV1
-	subsystemsSupport, err := c.ListSubsystemsQuick("/proc/self/cgroup")
+	subsystemsSupport, err := c.ListSubsystemsQuick("/proc/1/cgroup")
 	if err != nil {
 		return nil, fmt.Errorf("ListSubsystemsQuick() failed: %w", err)
 	}

--- a/pkg/cgroup/v1/subsystem_test.go
+++ b/pkg/cgroup/v1/subsystem_test.go
@@ -17,7 +17,7 @@ func TestE2E_ListTopLevelSubSystem(t *testing.T) {
 		expected []string
 	}{
 		"cve-2022-0492-host": {
-			expected: []string{"perf_event", "rdma", "hugetlb", "cpuset", "freezer", "net_cls", "net_prio"},
+			expected: []string{"perf_event", "rdma", "hugetlb", "cpuset", "freezer", "net_cls,net_prio"},
 		},
 		"cve-2022-0492-ctr": {
 			expected: []string{"rdma"},

--- a/prerequisite/kernel/cve-2022-0492/0492_ctr.go
+++ b/prerequisite/kernel/cve-2022-0492/0492_ctr.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
-
-	"errors"
 
 	"github.com/ctrsploit/ctrsploit/internal"
 	"github.com/ctrsploit/ctrsploit/pkg/mount"
@@ -57,17 +56,14 @@ func (p *vulnerableTo0492) Check() (bool, error) {
 				},
 			},
 		}
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err := cmd.Run()
+		out, err := cmd.CombinedOutput()
+		log.Logger.Debugf("\n%s", out)
 		if err != nil {
-			p.Satisfied = false
-			if errors.Is(err, os.ErrPermission) {
-				return
-			} else {
-				p.Err = p.WrapErr(fmt.Errorf("running %s: %w", cmd.Args, err))
-				return
-			}
+			p.Err = p.WrapErr(fmt.Errorf("running %s: %w", cmd.Args, err))
+			return
+		}
+		if strings.Contains(string(out), "no top level cgroup sub systems") {
+			return
 		}
 		p.Satisfied = true
 		return


### PR DESCRIPTION
…tect top-level subsystems

- Updated listTopLevelSubSystemQuick() to read from /proc/1/cgroup for accurate detection in host environment.
- Adjusted corresponding test expected value to reflect combined subsystems (net_cls,net_prio).
- Simplified CVE-2022-0492 container check logic to capture command output and handle "no top level cgroup sub systems" result properly.