### PR TITLE
prerequisite(kubernetes/service-account): add service account mount d…

### DIFF
--- a/prerequisite/kubernetes/service-account/e2e.yml
+++ b/prerequisite/kubernetes/service-account/e2e.yml
@@ -1,0 +1,75 @@
+name: service-account
+test_envs:
+  - name: kubernetes-v1.34.0-calico
+    kind: dqd
+    dqd_dir: kubernetes/v1.34.0-calico
+    pkg: github.com/ctrsploit/ctrsploit/prerequisite/kubernetes/service-account
+    cmd: |
+      until kubectl wait --for=condition=Ready pod --all -A --timeout=30s; do sleep 10; done
+      cat <<EOF | kubectl apply -f -
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: test-job
+      spec:
+        template:
+          spec:
+            restartPolicy: Never
+            containers:
+              - name: test-container
+                image: busybox:latest
+                tty: true
+                env: 
+                  - name: TEST_ENV
+                    value: mounted
+                command: ["/ctrsploit.test", "-test.v", "-test.run", "^TestE2E_ServiceAccount$"]
+                volumeMounts:
+                  - name: volume
+                    mountPath: /ctrsploit.test
+            volumes:
+              - name: volume
+                hostPath:
+                  path: /ctrsploit.test
+                  type: File
+      EOF
+      echo "Waiting for job 'test-job' to complete..."
+      kubectl wait --for=condition=complete job/test-job --timeout=120s
+      POD_NAME=$(kubectl get pods -l job-name=test-job -o jsonpath='{.items[0].metadata.name}')
+      kubectl logs $POD_NAME
+  - name: kubernetes-v1.34.0-calico
+    kind: dqd
+    dqd_dir: kubernetes/v1.34.0-calico
+    pkg: github.com/ctrsploit/ctrsploit/prerequisite/kubernetes/service-account
+    cmd: |
+      until kubectl wait --for=condition=Ready pod --all -A --timeout=30s; do sleep 10; done
+      cat <<EOF | kubectl apply -f -
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: test-job
+      spec:
+        template:
+          spec:
+            automountServiceAccountToken: false
+            restartPolicy: Never
+            containers:
+              - name: test-container
+                image: busybox:latest
+                tty: true
+                env: 
+                  - name: TEST_ENV
+                    value: not_mounted
+                command: ["/ctrsploit.test", "-test.v", "-test.run", "^TestE2E_ServiceAccount$"]
+                volumeMounts:
+                  - name: volume
+                    mountPath: /ctrsploit.test
+            volumes:
+              - name: volume
+                hostPath:
+                  path: /ctrsploit.test
+                  type: File
+      EOF
+      echo "Waiting for job 'test-job' to complete..."
+      kubectl wait --for=condition=complete job/test-job --timeout=120s
+      POD_NAME=$(kubectl get pods -l job-name=test-job -o jsonpath='{.items[0].metadata.name}')
+      kubectl logs $POD_NAME

--- a/prerequisite/kubernetes/service-account/mount.go
+++ b/prerequisite/kubernetes/service-account/mount.go
@@ -1,0 +1,19 @@
+package service_account
+
+import (
+	"os"
+
+	"github.com/ctrsploit/ctrsploit/prerequisite/mount/mountinfo/mountpoint"
+	"github.com/ctrsploit/sploit-spec/pkg/exeenv"
+	"github.com/ctrsploit/sploit-spec/pkg/prerequisite"
+)
+
+var ServiceAccount = mountpoint.ContainsMountPoint{
+	BasePrerequisite: prerequisite.BasePrerequisite{
+		Name:   "service-account mounted",
+		Info:   "",
+		ExeEnv: exeenv.InContainer,
+	},
+	ExpectedContains: "/run/secrets/kubernetes.io/serviceaccount",
+	Type:             os.ModeDir,
+}

--- a/prerequisite/kubernetes/service-account/mount_test.go
+++ b/prerequisite/kubernetes/service-account/mount_test.go
@@ -1,0 +1,31 @@
+package service_account
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestE2E_ServiceAccount(t *testing.T) {
+	testEnv := os.Getenv("TEST_ENV")
+	allTestcases := map[string]struct {
+		Satisfied bool
+	}{
+		"mounted": {
+			Satisfied: true,
+		},
+		"not_mounted": {
+			Satisfied: false,
+		},
+	}
+	testcase, ok := allTestcases[testEnv]
+	if !ok {
+		t.Skipf("Skipping test for unsupported environment: %s", testEnv)
+	}
+	t.Run(testEnv, func(t *testing.T) {
+		satisfied, err := ServiceAccount.Check()
+		assert.NoError(t, err)
+		assert.Equal(t, testcase.Satisfied, satisfied)
+	})
+}


### PR DESCRIPTION
…etection and E2E tests

- Add a new prerequisite module to detect the mount point of the Kubernetes service account (/run/secrets/kubernetes.io/serviceaccount).
- Include corresponding unit and end-to-end tests to verify behavior with and without automatic service account token mounting.