### PR TITLE
fix(upx): ctrsploit raise segment fault on arm64, caused by a upx bug

### DIFF
--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -20,11 +20,13 @@ WORKDIR /root/app
 RUN --mount=type=cache,sharing=locked,id=ctrsploit-build-aptlib,target=/var/lib/apt \
     --mount=type=cache,sharing=locked,id=ctrsploit-build-aptcache,target=/var/cache/apt \
     apt update && apt install -y \
-    upx \
+    xz-utils \
     jq \
     clang \
     llvm \
     libbpf-dev
+ADD https://github.com/upx/upx/releases/download/v5.0.2/upx-5.0.2-amd64_linux.tar.xz /tmp/upx.tar.xz
+RUN tar -xf /tmp/upx.tar.xz -C /tmp
 RUN --mount=type=bind,target=.,rw \
     --mount=type=cache,target=/root/.cache/go-build,id=ctrsploit-build \
     --mount=type=cache,target=/go/pkg/mod,id=ctrsploit-mod \


### PR DESCRIPTION
install latest upx by download static linked binary from github directly.