### PR TITLE
refactor(service-account): rename ServiceAccount to Mounted and updat…

### DIFF
--- a/prerequisite/kubernetes/service-account/e2e.yml
+++ b/prerequisite/kubernetes/service-account/e2e.yml
@@ -22,7 +22,7 @@ test_envs:
                 env: 
                   - name: TEST_ENV
                     value: mounted
-                command: ["/ctrsploit.test", "-test.v", "-test.run", "^TestE2E_ServiceAccount$"]
+                command: ["/ctrsploit.test", "-test.v", "-test.run", "^TestE2E_ServiceAccountMounted$"]
                 volumeMounts:
                   - name: volume
                     mountPath: /ctrsploit.test
@@ -59,7 +59,7 @@ test_envs:
                 env: 
                   - name: TEST_ENV
                     value: not_mounted
-                command: ["/ctrsploit.test", "-test.v", "-test.run", "^TestE2E_ServiceAccount$"]
+                command: ["/ctrsploit.test", "-test.v", "-test.run", "^TestE2E_ServiceAccountMounted$"]
                 volumeMounts:
                   - name: volume
                     mountPath: /ctrsploit.test

--- a/prerequisite/kubernetes/service-account/mount.go
+++ b/prerequisite/kubernetes/service-account/mount.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ctrsploit/sploit-spec/pkg/prerequisite"
 )
 
-var ServiceAccount = mountpoint.ContainsMountPoint{
+var Mounted = mountpoint.ContainsMountPoint{
 	BasePrerequisite: prerequisite.BasePrerequisite{
 		Name:   "service-account mounted",
 		Info:   "",

--- a/prerequisite/kubernetes/service-account/mount_test.go
+++ b/prerequisite/kubernetes/service-account/mount_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestE2E_ServiceAccount(t *testing.T) {
+func TestE2E_ServiceAccountMounted(t *testing.T) {
 	testEnv := os.Getenv("TEST_ENV")
 	allTestcases := map[string]struct {
 		Satisfied bool
@@ -24,7 +24,7 @@ func TestE2E_ServiceAccount(t *testing.T) {
 		t.Skipf("Skipping test for unsupported environment: %s", testEnv)
 	}
 	t.Run(testEnv, func(t *testing.T) {
-		satisfied, err := ServiceAccount.Check()
+		satisfied, err := Mounted.Check()
 		assert.NoError(t, err)
 		assert.Equal(t, testcase.Satisfied, satisfied)
 	})


### PR DESCRIPTION
…e related test names

- Renamed variable `ServiceAccount` to `Mounted` in mount.go for clarity.
- Updated corresponding test function name to `TestE2E_ServiceAccountMounted`.
- Adjusted test commands in e2e.yml to match the new test function name.