### PR TITLE
refactor(k8s): extract secret access check logic and rename package

### DIFF
--- a/pkg/kubernetes/secret/pod.go
+++ b/pkg/kubernetes/secret/pod.go
@@ -1,4 +1,4 @@
-package kubernetes
+package secret
 
 import (
 	"context"

--- a/pkg/kubernetes/secret/pod_example_test.go
+++ b/pkg/kubernetes/secret/pod_example_test.go
@@ -1,4 +1,4 @@
-package kubernetes
+package secret
 
 import (
 	"context"

--- a/pkg/kubernetes/secret/pod_test.go
+++ b/pkg/kubernetes/secret/pod_test.go
@@ -1,4 +1,4 @@
-package kubernetes
+package secret
 
 import (
 	"context"

--- a/pkg/kubernetes/secret/role.go
+++ b/pkg/kubernetes/secret/role.go
@@ -1,4 +1,4 @@
-package kubernetes
+package secret
 
 import (
 	"context"

--- a/pkg/kubernetes/secret/role_test.go
+++ b/pkg/kubernetes/secret/role_test.go
@@ -1,4 +1,4 @@
-package kubernetes
+package secret
 
 import (
 	"context"

--- a/pkg/kubernetes/secret/serviceaccount.go
+++ b/pkg/kubernetes/secret/serviceaccount.go
@@ -1,4 +1,4 @@
-package kubernetes
+package secret
 
 import (
 	"context"

--- a/pkg/kubernetes/secret/serviceaccount_test.go
+++ b/pkg/kubernetes/secret/serviceaccount_test.go
@@ -1,4 +1,4 @@
-package kubernetes
+package secret
 
 import (
 	"context"

--- a/vul/sa-token/access-secrets/check.go
+++ b/vul/sa-token/access-secrets/check.go
@@ -1,0 +1,102 @@
+package access_secrets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ctrsploit/ctrsploit/pkg/kubernetes/secret"
+	prerequisiteSecret "github.com/ctrsploit/ctrsploit/prerequisite/kubernetes/service-account/secret"
+	"github.com/ctrsploit/sploit-spec/pkg/log"
+)
+
+// Check checks for pods with secret access and prints the analysis results.
+// This function can be used by other projects to check and report secret access.
+func Check() error {
+	pods, err := prerequisiteSecret.GetPodsWithSecretAccess(&prerequisiteSecret.HasPodsWithSecretAccess)
+	if err != nil {
+		return fmt.Errorf("failed to get pods with secret access: %w", err)
+	}
+	Report(pods)
+	return nil
+}
+
+// Report prints the analysis results for the given pods with secret access.
+// This function can be used by other projects to print secret access analysis results.
+func Report(pods []secret.PodWithSecretAccess) {
+	if len(pods) == 0 {
+		log.Logger.Infof("No pods with secret access found")
+		return
+	}
+
+	// Collect cluster-wide statistics
+	allNamespaces := make(map[string]bool)
+	allPermissions := make(map[string]bool)
+	namespacePodCount := make(map[string]int)
+	serviceAccountMap := make(map[string]map[string]bool) // namespace -> serviceAccount -> true
+	namespacePermissions := make(map[string][]secret.ServiceAccountPermission)
+
+	for _, pod := range pods {
+		allNamespaces[pod.Namespace] = true
+		namespacePodCount[pod.Namespace]++
+
+		// Track service accounts
+		if serviceAccountMap[pod.Namespace] == nil {
+			serviceAccountMap[pod.Namespace] = make(map[string]bool)
+		}
+		serviceAccountMap[pod.Namespace][pod.ServiceAccountName] = true
+
+		// Track unique permissions
+		for _, perm := range pod.Permissions {
+			permKey := fmt.Sprintf("%s/%s/%s", perm.BindingKind, perm.RoleRefKind, perm.RoleRefName)
+			allPermissions[permKey] = true
+
+			// Track permissions per namespace (deduplicate)
+			seenPermKey := fmt.Sprintf("%s/%s/%s/%s", perm.BindingKind, perm.RoleRefKind, perm.RoleRefName, strings.Join(perm.Verbs, ","))
+			if namespacePermissions[pod.Namespace] == nil {
+				namespacePermissions[pod.Namespace] = make([]secret.ServiceAccountPermission, 0)
+			}
+			// Check if this permission is already in the list for this namespace
+			found := false
+			for _, existingPerm := range namespacePermissions[pod.Namespace] {
+				existingPermKey := fmt.Sprintf("%s/%s/%s/%s", existingPerm.BindingKind, existingPerm.RoleRefKind, existingPerm.RoleRefName, strings.Join(existingPerm.Verbs, ","))
+				if existingPermKey == seenPermKey {
+					found = true
+					break
+				}
+			}
+			if !found {
+				namespacePermissions[pod.Namespace] = append(namespacePermissions[pod.Namespace], perm)
+			}
+		}
+	}
+
+	// Display cluster-wide information
+	log.Logger.Infof("")
+	log.Logger.Infof("=== Cluster-wide Pods with Secret Access ===")
+	log.Logger.Infof("Found %d pod(s) with secret access permissions across the cluster", len(pods))
+
+	// Display pods grouped by namespace
+	log.Logger.Infof("")
+	log.Logger.Infof("=== Pods by Namespace ===")
+	for namespace := range allNamespaces {
+		log.Logger.Infof("")
+		log.Logger.Infof("Namespace: %s", namespace)
+		log.Logger.Infof("  Pods: %d", namespacePodCount[namespace])
+		log.Logger.Infof("  Service Accounts: %d", len(serviceAccountMap[namespace]))
+
+		// Show unique RBAC permissions for this namespace
+		if perms, exists := namespacePermissions[namespace]; exists && len(perms) > 0 {
+			log.Logger.Infof("  RBAC Permissions:")
+			for _, perm := range perms {
+				log.Logger.Infof("    - [%s] %s (Scope: %s, Verbs: %s)", perm.BindingKind, perm.RoleRefName, perm.Scope(), strings.Join(perm.Verbs, ","))
+			}
+		}
+	}
+
+	// Display summary
+	log.Logger.Infof("")
+	log.Logger.Infof("=== Summary ===")
+	log.Logger.Infof("Total pods with secret access: %d", len(pods))
+	log.Logger.Infof("Namespaces affected: %d", len(allNamespaces))
+	log.Logger.Infof("Unique RBAC permissions: %d", len(allPermissions))
+}

--- a/vul/sa-token/access-secrets/vul.go
+++ b/vul/sa-token/access-secrets/vul.go
@@ -2,9 +2,8 @@ package access_secrets
 
 import (
 	"fmt"
-	"strings"
 
-	sa_secret "github.com/ctrsploit/ctrsploit/prerequisite/kubernetes/service-account/secret"
+	"github.com/ctrsploit/ctrsploit/prerequisite/kubernetes/service-account/secret"
 	"github.com/ctrsploit/sploit-spec/pkg/app"
 	"github.com/ctrsploit/sploit-spec/pkg/exeenv"
 	"github.com/ctrsploit/sploit-spec/pkg/log"
@@ -47,7 +46,7 @@ var Vul = vulnerability{
 			Env:   exeenv.K8S,
 			Check: exeenv.K8S,
 		},
-		CheckSecPrerequisites:    &sa_secret.HasPodsWithSecretAccess,
+		CheckSecPrerequisites:    &secret.HasPodsWithSecretAccess,
 		ExploitablePrerequisites: nil,
 	},
 }
@@ -65,78 +64,10 @@ func (v *vulnerability) CheckSec(ctx *cli.Context) (satisfied bool, err error) {
 		return false, nil
 	}
 
-	// Get pods with secret access from the prerequisite
-	pods, err := sa_secret.GetPodsWithSecretAccess(&sa_secret.HasPodsWithSecretAccess)
-	if err != nil {
-		return false, fmt.Errorf("failed to get pods with secret access: %w", err)
+	// Report the results using the exported function
+	if err := Check(); err != nil {
+		return false, err
 	}
-
-	if len(pods) == 0 {
-		log.Logger.Info("No pods with secret access found")
-		return false, nil
-	}
-
-	// Collect cluster-wide statistics
-	allNamespaces := make(map[string]bool)
-	allPermissions := make(map[string]bool)
-	namespacePodCount := make(map[string]int)
-	serviceAccountMap := make(map[string]map[string]bool) // namespace -> serviceAccount -> true
-
-	for _, pod := range pods {
-		allNamespaces[pod.Namespace] = true
-		namespacePodCount[pod.Namespace]++
-
-		// Track service accounts
-		if serviceAccountMap[pod.Namespace] == nil {
-			serviceAccountMap[pod.Namespace] = make(map[string]bool)
-		}
-		serviceAccountMap[pod.Namespace][pod.ServiceAccountName] = true
-
-		// Track unique permissions
-		for _, perm := range pod.Permissions {
-			permKey := fmt.Sprintf("%s/%s/%s", perm.BindingKind, perm.RoleRefKind, perm.RoleRefName)
-			allPermissions[permKey] = true
-		}
-	}
-
-	// Display cluster-wide information
-	log.Logger.Infof("")
-	log.Logger.Infof("=== Cluster-wide Pods with Secret Access ===")
-	log.Logger.Infof("Found %d pod(s) with secret access permissions across the cluster", len(pods))
-
-	// Display pods grouped by namespace
-	log.Logger.Infof("")
-	log.Logger.Infof("=== Pods by Namespace ===")
-	for namespace := range allNamespaces {
-		log.Logger.Infof("")
-		log.Logger.Infof("Namespace: %s", namespace)
-		log.Logger.Infof("  Pods: %d", namespacePodCount[namespace])
-		log.Logger.Infof("  Service Accounts: %d", len(serviceAccountMap[namespace]))
-
-		// Show unique RBAC permissions for this namespace
-		seenPerms := make(map[string]bool)
-		for _, pod := range pods {
-			if pod.Namespace == namespace {
-				for _, perm := range pod.Permissions {
-					permKey := fmt.Sprintf("%s/%s/%s/%s", perm.BindingKind, perm.RoleRefKind, perm.RoleRefName, strings.Join(perm.Verbs, ","))
-					if !seenPerms[permKey] {
-						seenPerms[permKey] = true
-						if len(seenPerms) == 1 {
-							log.Logger.Infof("  RBAC Permissions:")
-						}
-						log.Logger.Infof("    - [%s] %s (Scope: %s, Verbs: %s)", perm.BindingKind, perm.RoleRefName, perm.Scope(), strings.Join(perm.Verbs, ","))
-					}
-				}
-			}
-		}
-	}
-
-	// Display summary
-	log.Logger.Infof("")
-	log.Logger.Infof("=== Summary ===")
-	log.Logger.Infof("Total pods with secret access: %d", len(pods))
-	log.Logger.Infof("Namespaces affected: %d", len(allNamespaces))
-	log.Logger.Infof("Unique RBAC permissions: %d", len(allPermissions))
 
 	return true, nil
 }


### PR DESCRIPTION
Refactor Kubernetes secret package structure and extract reusable check logic. Change package name from `kubernetes` to `secret` for all files in `pkg/kubernetes/secret/` to better align with subpackage naming conventions.

Add new `check.go` file in `vul/sa-token/access-secrets/` containing exported `Check()` and `Report()` functions for checking and reporting pods with secret access permissions. These functions can be reused by other projects.

Refactor `CheckSec()` method in `vul.go` to delegate to the `Check()` function instead of inlining the reporting logic. Improve permission deduplication in `Report()` function by using `namespacePermissions` map to deduplicate permissions per namespace, replacing the previous temporary `seenPerms` map approach.