### PR TITLE
doc(cve-2024-40635): update image tag from latest to v0.1.0 and remov…

### DIFF
--- a/vul/cve-2024-40635/README.md
+++ b/vul/cve-2024-40635/README.md
@@ -4,8 +4,9 @@ tags: sploit
 author:
     - r0binak
     - ssst0n3
-version: v0.1.1
+version: v0.1.2
 changelog:
+    - v0.1.2: remove redundant imagePullPolicy note
     - v0.1.1: refine semver constraint and CLI/test tooling
     - v0.1.0: init
 
@@ -96,8 +97,8 @@ root@kubernetes-1-32-2-containerd-2-0-3:~# ctrsploit vul 40635 c
 
 root@kubernetes-1-32-2-containerd-2-0-3:~# ctrsploit vul 40635 x
 INFO[0000] exploit generated in poc-cve-2024-40635 directory 
-INFO[0000] 1. Build the image: docker build -t cve-2024-40635:latest poc-cve-2024-40635 
-INFO[0000] 2. Push the image to your registry: docker push cve-2024-40635:latest 
+INFO[0000] 1. Build the image: docker build -t your-registry/cve-2024-40635:v0.1.0 poc-cve-2024-40635 
+INFO[0000] 2. Push the image to your registry: docker push your-registry/cve-2024-40635:v0.1.0 
 INFO[0000] 3. Update the image name in poc-cve-2024-40635/pod.yaml and apply: kubectl apply -f poc-cve-2024-40635/pod.yaml 
 INFO[0000] 4. Check if the pod runs as root: kubectl exec pod-run-as-non-root -- id
 ```
@@ -105,13 +106,13 @@ INFO[0000] 4. Check if the pod runs as root: kubectl exec pod-run-as-non-root --
 #### (2) Build image
 
 ```shell
-root@kubernetes-1-32-2-containerd-2-0-3:~# nerdctl --namespace k8s.io build -t your-registry/cve-2024-40635:latest poc-cve-2024-40635
+root@kubernetes-1-32-2-containerd-2-0-3:~# nerdctl --namespace k8s.io build -t your-registry/cve-2024-40635:v0.1.0 poc-cve-2024-40635
 ```
 
 #### (3) (Optional) Push image
 
 ```shell
-root@kubernetes-1-32-2-containerd-2-0-3:~# nerdctl push your-registry/cve-2024-40635:latest
+root@kubernetes-1-32-2-containerd-2-0-3:~# nerdctl push your-registry/cve-2024-40635:v0.1.0
 ```
 
 #### (4) Deploy to Kubernetes
@@ -126,15 +127,13 @@ metadata:
 spec:
   containers:
     - name: ubuntu
-      image: your-registry/cve-2024-40635:latest
+      image: your-registry/cve-2024-40635:v0.1.0
       command:
         - sleep
         - infinity
       securityContext:
         runAsNonRoot: true
 ```
-
-Insert `imagePullPolicy: Never` into pod.yaml if use local image instead of remote registry.
 
 Apply the manifest:
 

--- a/vul/cve-2024-40635/material/pod.yaml
+++ b/vul/cve-2024-40635/material/pod.yaml
@@ -6,7 +6,7 @@ spec:
   containers:
     - name: ubuntu
       # Replace with your image after building and pushing
-      image: your-registry/cve-2024-40635:latest
+      image: your-registry/cve-2024-40635:v0.1.0
       command:
         - sleep
         - infinity

--- a/vul/cve-2024-40635/vul.go
+++ b/vul/cve-2024-40635/vul.go
@@ -15,7 +15,7 @@ var (
 			Name:    "image",
 			Aliases: []string{"i"},
 			Usage:   "image name to build",
-			Value:   "cve-2024-40635:latest",
+			Value:   "your-registry/cve-2024-40635:v0.1.0",
 		},
 		&cli.StringFlag{
 			Name:    "dir",


### PR DESCRIPTION
…e redundant note

- Update image tag from :latest to :v0.1.0 in all docs and config files
- Remove redundant imagePullPolicy note
- Update version from v0.1.1 to v0.1.2