### PR TITLE
docs: move Build/Progress from README to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,7 @@ apt install docker-buildx-plugin
 If it still doesn't work, try:
 1. Reinstall Docker by following the [official docker documentation](https://docs.docker.com/engine/install/)
 2. Check if there is a file at `~/.docker/cli-plugins/docker-buildx`, (if there is, remove it)
+
+## 3. Progress of Development
+
+See [vul/README.md](./vul/README.md) for the full vulnerability module status.

--- a/README.md
+++ b/README.md
@@ -163,12 +163,6 @@ ctrsploit env services   # discover cluster services without API access
 
 For full `env` subcommands and flags, run `ctrsploit env --help`.
 
-## Build
+## Contributing
 
-```bash
-make binary     # build in container
-```
-
-## Progress of Development
-
-* [vul](./vul/README.md)
+See [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
Replace Build and Progress of Development sections in README with a link to CONTRIBUTING.md. Add Progress section to CONTRIBUTING.md.